### PR TITLE
Equilize exception handle in Cloud

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -313,7 +313,7 @@ class MeijuCloud(MideaCloud):
         ):
             try:
                 model_number = int(response.get("modelNumber", 0))
-            except ValueError:
+            except (ValueError, TypeError):
                 model_number = 0
             model_type = response.get("type")
             device_info = {


### PR DESCRIPTION
For some reason the exceptions expected were diferent in `list_appliances` and `get_device_info`.