### PR TITLE
fix(a1): attribute with wrong default

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -10,6 +10,7 @@ from .message import (
     MessageApplianceResponse,
     MessageQueryAppliance,
     MessageQuestCustom,
+    MessageRequest,
     MessageType,
 )
 from .packet_builder import PacketBuilder
@@ -196,7 +197,7 @@ class MideaDevice(threading.Thread):
         data = self._security.encode_8370(data, msg_type)
         self.send_message_v2(data)
 
-    def build_send(self, cmd: MessageQuestCustom) -> None:
+    def build_send(self, cmd: MessageRequest) -> None:
         data = cmd.serialize()
         _LOGGER.debug("[%s] Sending: %s", self._device_id, cmd)
         msg = PacketBuilder(self._device_id, data).finalize()

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -4,7 +4,6 @@ from .message import MessageQuery, MessageA1Response, MessageSet
 
 import sys
 
-from .message import MessageA1Response, MessageQuery, MessageSet
 
 if sys.version_info < (3, 12):
     from ...backports.enum import StrEnum
@@ -73,7 +72,7 @@ class MideaA1Device(MideaDevice):
                 DeviceAttributes.prompt_tone: True,
                 DeviceAttributes.child_lock: False,
                 DeviceAttributes.mode: None,
-                DeviceAttributes.fan_speed: 60,
+                DeviceAttributes.fan_speed: "Medium",
                 DeviceAttributes.swing: False,
                 DeviceAttributes.target_humidity: 35,
                 DeviceAttributes.anion: False,

--- a/midealocal/devices/a1/message.py
+++ b/midealocal/devices/a1/message.py
@@ -32,11 +32,11 @@ class MessageA1Base(MessageRequest):
         self._message_id = MessageA1Base._message_serial
 
     @property
-    def _body(self):
+    def _body(self) -> bytearray:
         raise NotImplementedError
 
     @property
-    def body(self):
+    def body(self) -> bytearray:
         body = bytearray([self.body_type]) + self._body + bytearray([self._message_id])
         body.append(calculate(body))
         return body
@@ -163,7 +163,7 @@ class MessageNewProtocolSet(MessageA1Base):
             message_type=MessageType.set,
             body_type=0xB0,
         )
-        self.light = None
+        self.light: bool | None = None
 
     @property
     def _body(self) -> bytearray:
@@ -200,7 +200,7 @@ class A1GeneralMessageBody(MessageBody):
 
 
 class A1NewProtocolMessageBody(NewProtocolMessageBody):
-    def __init__(self, body: bytearray, bt) -> None:
+    def __init__(self, body: bytearray, bt: int) -> None:
         super().__init__(body, bt)
         params = self.parse()
         if NewProtocolTags.light in params:


### PR DESCRIPTION
Here it saves the string value instead of the index. The index is used only inside the message:
```
                elif status == DeviceAttributes.fan_speed:
                    if value in MideaA1Device._speeds.keys():
                        self._attributes[status] = MideaA1Device._speeds.get(value)
                    else:
                        self._attributes[status] = None
```

That's why fan_speed should be a string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the `fan_speed` attribute to display string values instead of integers.
- **New Features**
	- Enhanced type safety with added type annotations in various methods and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->