### PR TITLE
chore: typing e3

### DIFF
--- a/midealocal/devices/e3/__init__.py
+++ b/midealocal/devices/e3/__init__.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from typing import Any
 
 from .message import (
     MessageE3Response,
@@ -44,7 +45,7 @@ class MideaE3Device(MideaDevice):
         model: str,
         subtype: int,
         customize: str,
-    ):
+    ) -> None:
         super().__init__(
             name=name,
             device_id=device_id,
@@ -68,18 +69,18 @@ class MideaE3Device(MideaDevice):
             },
         )
         self._old_subtypes = [32, 33, 34, 35, 36, 37, 40, 43, 48, 49, 80]
-        self._precision_halves = None
+        self._precision_halves: bool | None = None
         self._default_precision_halves = False
         self.set_customize(customize)
 
     @property
-    def precision_halves(self):
+    def precision_halves(self) -> bool | None:
         return self._precision_halves
 
-    def build_query(self):
+    def build_query(self) -> list[MessageQuery]:
         return [MessageQuery(self._protocol_version)]
 
-    def process_message(self, msg):
+    def process_message(self, msg: bytes) -> dict[str, Any]:
         message = MessageE3Response(msg)
         _LOGGER.debug(f"[{self.device_id}] Received: {message}")
         new_status = {}
@@ -96,18 +97,19 @@ class MideaE3Device(MideaDevice):
 
         return new_status
 
-    def make_message_set(self):
+    def make_message_set(self) -> MessageSet:
         message = MessageSet(self._protocol_version)
         message.zero_cold_water = self._attributes[DeviceAttributes.zero_cold_water]
         message.protection = self._attributes[DeviceAttributes.protection]
-        message.zero_clod_pulse = self._attributes[DeviceAttributes.zero_cold_pulse]
+        message.zero_cold_pulse = self._attributes[DeviceAttributes.zero_cold_pulse]
         message.smart_volume = self._attributes[DeviceAttributes.smart_volume]
         message.target_temperature = self._attributes[
             DeviceAttributes.target_temperature
         ]
         return message
 
-    def set_attribute(self, attr, value):
+    def set_attribute(self, attr: str, value: Any) -> None:
+        message: MessagePower | MessageSet | MessageNewProtocolSet | None = None
         if attr not in [
             DeviceAttributes.burning_state,
             DeviceAttributes.current_temperature,
@@ -127,7 +129,7 @@ class MideaE3Device(MideaDevice):
                 message.value = value
             self.build_send(message)
 
-    def set_customize(self, customize):
+    def set_customize(self, customize: str) -> None:
         self._precision_halves = self._default_precision_halves
         if customize and len(customize) > 0:
             try:

--- a/midealocal/devices/e3/message.py
+++ b/midealocal/devices/e3/message.py
@@ -7,6 +7,7 @@ from ...message import (
 )
 
 NEW_PROTOCOL_PARAMS = {
+    "none": 0x00,
     "zero_cold_water": 0x03,
     # "zero_cold_master": 0x12,
     "zero_cold_pulse": 0x04,
@@ -115,7 +116,7 @@ class MessageNewProtocolSet(MessageE3Base):
             message_type=MessageType.set,
             body_type=0x14,
         )
-        self.key: str | None = None
+        self.key = "none"
         self.value: Any = None
 
     @property

--- a/midealocal/devices/e3/message.py
+++ b/midealocal/devices/e3/message.py
@@ -1,3 +1,4 @@
+from typing import Any
 from ...message import (
     MessageBody,
     MessageRequest,
@@ -15,7 +16,9 @@ NEW_PROTOCOL_PARAMS = {
 
 
 class MessageE3Base(MessageRequest):
-    def __init__(self, protocol_version, message_type, body_type):
+    def __init__(
+        self, protocol_version: int, message_type: int, body_type: int
+    ) -> None:
         super().__init__(
             device_type=0xE3,
             protocol_version=protocol_version,
@@ -24,12 +27,12 @@ class MessageE3Base(MessageRequest):
         )
 
     @property
-    def _body(self):
+    def _body(self) -> bytearray:
         raise NotImplementedError
 
 
 class MessageQuery(MessageE3Base):
-    def __init__(self, protocol_version):
+    def __init__(self, protocol_version: int) -> None:
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.query,
@@ -37,12 +40,12 @@ class MessageQuery(MessageE3Base):
         )
 
     @property
-    def _body(self):
+    def _body(self) -> bytearray:
         return bytearray([0x01])
 
 
 class MessagePower(MessageE3Base):
-    def __init__(self, protocol_version):
+    def __init__(self, protocol_version: int) -> None:
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
@@ -51,7 +54,7 @@ class MessagePower(MessageE3Base):
         self.power = False
 
     @property
-    def _body(self):
+    def _body(self) -> bytearray:
         if self.power:
             self.body_type = 0x01
         else:
@@ -60,7 +63,7 @@ class MessagePower(MessageE3Base):
 
 
 class MessageSet(MessageE3Base):
-    def __init__(self, protocol_version):
+    def __init__(self, protocol_version: int) -> None:
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
@@ -75,7 +78,7 @@ class MessageSet(MessageE3Base):
         self.smart_volume = False
 
     @property
-    def _body(self):
+    def _body(self) -> bytearray:
         # Byte 2 zero_cold_water mode
         zero_cold_water = 0x01 if self.zero_cold_water else 0x00
         # Byte 3
@@ -106,18 +109,18 @@ class MessageSet(MessageE3Base):
 
 
 class MessageNewProtocolSet(MessageE3Base):
-    def __init__(self, protocol_version):
+    def __init__(self, protocol_version: int) -> None:
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
             body_type=0x14,
         )
-        self.key = None
-        self.value = None
+        self.key: str | None = None
+        self.value: Any = None
 
     @property
-    def _body(self):
-        key = NEW_PROTOCOL_PARAMS.get(self.key)
+    def _body(self) -> bytearray:
+        key = NEW_PROTOCOL_PARAMS[self.key]
         if self.key == "target_temperature":
             value = self.value
         else:
@@ -148,7 +151,7 @@ class MessageNewProtocolSet(MessageE3Base):
 
 
 class E3GeneralMessageBody(MessageBody):
-    def __init__(self, body):
+    def __init__(self, body: bytearray) -> None:
         super().__init__(body)
         self.power = (body[2] & 0x01) > 0
         self.burning_state = (body[2] & 0x02) > 0
@@ -161,8 +164,8 @@ class E3GeneralMessageBody(MessageBody):
 
 
 class MessageE3Response(MessageResponse):
-    def __init__(self, message):
-        super().__init__(message)
+    def __init__(self, message: bytes) -> None:
+        super().__init__(bytearray(message))
         if (
             (self.message_type == MessageType.query and self.body_type == 0x01)
             or (


### PR DESCRIPTION
Draft because of a issue `self.key` in:

```python
key = NEW_PROTOCOL_PARAMS[self.key]
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced type hints across various methods for enhanced code clarity and type safety.

- **Improvements**
  - Added more explicit type annotations for method parameters and return types to improve code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->