### PR TITLE
use `tempfile.gettempdir()` for tmp dir

### DIFF
--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1,6 +1,7 @@
 """Test cloud"""
 
 import os
+from tempfile import gettempdir
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock
 
@@ -261,17 +262,18 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         assert await cloud.login()
 
-        if not os.path.exists("/tmp/download"):
-            os.mkdir("/tmp/download")
-        file = await cloud.download_lua("/tmp/download", 10, "00000000", "0xAC", "0010")
+        tmp_download = os.path.join(gettempdir(), "download")
+        if not os.path.exists(tmp_download):
+            os.mkdir(tmp_download)
+        file = await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
         assert file is not None
         assert os.path.exists(file)
         os.remove(file)
-        os.removedirs("/tmp/download")
+        os.removedirs(tmp_download)
 
         res.status = 404
         assert (
-            await cloud.download_lua("/tmp/download", 10, "00000000", "0xAC", "0010")
+            await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
             is None
         )
 
@@ -439,13 +441,14 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         assert await cloud.login()
 
-        if not os.path.exists("/tmp/download"):
-            os.mkdir("/tmp/download")
-        file = await cloud.download_lua("/tmp/download", 10, "00000000", "0xAC", "0010")
+        tmp_download = os.path.join(gettempdir(), "download")
+        if not os.path.exists(tmp_download):
+            os.mkdir(tmp_download)
+        file = await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
         assert file is not None
         assert os.path.exists(file)
         os.remove(file)
-        os.removedirs("/tmp/download")
+        os.removedirs(tmp_download)
 
     async def test_mideaaircloud_login_success(self) -> None:
         """Test MideaAirCloud login"""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1,7 +1,7 @@
 """Test cloud"""
 
 import os
-from tempfile import gettempdir
+from tempfile import TemporaryDirectory
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock
 
@@ -262,20 +262,16 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         assert await cloud.login()
 
-        tmp_download = os.path.join(gettempdir(), "download")
-        if not os.path.exists(tmp_download):
-            os.mkdir(tmp_download)
-        file = await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
-        assert file is not None
-        assert os.path.exists(file)
-        os.remove(file)
-        os.removedirs(tmp_download)
+        with TemporaryDirectory() as tmpdir:
+            file = await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
+            assert file is not None
+            assert os.path.exists(file)
+            os.remove(file)
 
-        res.status = 404
-        assert (
-            await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
-            is None
-        )
+            res.status = 404
+            assert (
+                await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010") is None
+            )
 
     async def test_msmartcloud_login_success(self) -> None:
         """Test MSmartCloud login"""
@@ -441,14 +437,11 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         assert await cloud.login()
 
-        tmp_download = os.path.join(gettempdir(), "download")
-        if not os.path.exists(tmp_download):
-            os.mkdir(tmp_download)
-        file = await cloud.download_lua(tmp_download, 10, "00000000", "0xAC", "0010")
-        assert file is not None
-        assert os.path.exists(file)
-        os.remove(file)
-        os.removedirs(tmp_download)
+        with TemporaryDirectory() as tmpdir:
+            file = await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
+            assert file is not None
+            assert os.path.exists(file)
+            os.remove(file)
 
     async def test_mideaaircloud_login_success(self) -> None:
         """Test MideaAirCloud login"""


### PR DESCRIPTION
`/tmp` not exist on Windows ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by dynamically obtaining paths for temporary downloads.

- **Chores**
  - Expanded build job to include Windows and macOS platforms in addition to Ubuntu for better cross-platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->