### PR TITLE
fix: body_type NONE_VALUE checks

### DIFF
--- a/midealocal/devices/e6/message.py
+++ b/midealocal/devices/e6/message.py
@@ -3,6 +3,7 @@ from ...message import (
     MessageRequest,
     MessageResponse,
     MessageType,
+    NONE_VALUE,
 )
 
 
@@ -12,7 +13,7 @@ class MessageE6Base(MessageRequest):
             device_type=0xE6,
             protocol_version=protocol_version,
             message_type=message_type,
-            body_type=None,
+            body_type=NONE_VALUE,
         )
 
     @property

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -90,7 +90,7 @@ class MessageBase(ABC):
             "body": self.body.hex(),
             "message type": "%02x" % self._message_type,
             "body type": (
-                ("%02x" % self._body_type) if self._body_type is not NONE_VALUE else "None"
+                ("%02x" % self._body_type) if self._body_type != NONE_VALUE else "None"
             ),
         }
         return str(output)
@@ -144,7 +144,7 @@ class MessageRequest(MessageBase):
     @property
     def body(self) -> bytearray:
         body = bytearray([])
-        if self.body_type is not NONE_VALUE:
+        if self.body_type != NONE_VALUE:
             body.append(self.body_type)
         if self._body is not None:
             body.extend(self._body)

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -90,7 +90,7 @@ class MessageBase(ABC):
             "body": self.body.hex(),
             "message type": "%02x" % self._message_type,
             "body type": (
-                ("%02x" % self._body_type) if self._body_type is not None else "None"
+                ("%02x" % self._body_type) if self._body_type is not NONE_VALUE else "None"
             ),
         }
         return str(output)
@@ -144,7 +144,7 @@ class MessageRequest(MessageBase):
     @property
     def body(self) -> bytearray:
         body = bytearray([])
-        if self.body_type is not None:
+        if self.body_type is not NONE_VALUE:
             body.append(self.body_type)
         if self._body is not None:
             body.extend(self._body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `body_type` parameter to prevent errors by using `NONE_VALUE` instead of `None` in message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->