### PR TITLE
add windows and macos build test in github action

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.12", "3.11", "3.10"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -25,6 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov genbadge[all]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        shell: bash
       - name: Build midea-local
         run: |
           python -m build


### PR DESCRIPTION
use windows-latest and macos-latest to test python-build in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build workflow to support multiple operating systems (Windows, Ubuntu, macOS) for better compatibility and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->