### PR TITLE
fix: normalize old_protocol for E2

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -89,6 +89,9 @@ class MideaE2Device(MideaDevice):
         try:
             if isinstance(value, str):
                 value = OldProtocol(value)
+                if value == OldProtocol.auto:
+                    result = self.subtype <= 82 or self.subtype == 85 or self.subtype == 36353
+                    value = OldProtocol.true if result else OldProtocol.false
             elif isinstance(value, int) or isinstance(value, bool):
                 value = OldProtocol.true if value else OldProtocol.false
             else:

--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -89,9 +89,9 @@ class MideaE2Device(MideaDevice):
         try:
             if isinstance(value, str):
                 value = OldProtocol(value)
-            elif isinstance(value, int):
+            elif isinstance(value, int) or isinstance(value, bool):
                 value = OldProtocol.true if value else OldProtocol.false
-            if not isinstance(value, OldProtocol):
+            else:
                 raise ValueError("Invalid value for old_protocol")
             return value
         except ValueError as e:

--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -85,7 +85,7 @@ class MideaE2Device(MideaDevice):
         self._old_protocol = self._default_old_protocol
         self.set_customize(customize)
 
-    def normalize_old_protocol(self, value: Any) -> OldProtocol:
+    def _normalize_old_protocol(self, value: Any) -> OldProtocol:
         result: bool
         if isinstance(value, str) and value in OldProtocol:
             if value == OldProtocol.auto:
@@ -135,7 +135,7 @@ class MideaE2Device(MideaDevice):
             DeviceAttributes.keep_warm,
             DeviceAttributes.current_temperature,
         ]:
-            old_protocol = self.normalize_old_protocol(self._old_protocol)
+            old_protocol = self._normalize_old_protocol(self._old_protocol)
             if attr == DeviceAttributes.power:
                 message = MessagePower(self._protocol_version)
                 message.power = value
@@ -153,7 +153,7 @@ class MideaE2Device(MideaDevice):
             try:
                 params = json.loads(customize)
                 if params and "old_protocol" in params:
-                    self._old_protocol = self.normalize_old_protocol(
+                    self._old_protocol = self._normalize_old_protocol(
                         params["old_protocol"]
                     )
             except Exception as e:

--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -86,22 +86,17 @@ class MideaE2Device(MideaDevice):
         self.set_customize(customize)
 
     def _normalize_old_protocol(self, value: Any) -> OldProtocol:
-        result: bool
-        if isinstance(value, str) and value in OldProtocol:
-            if value == OldProtocol.auto:
-                result = (
-                    self.subtype <= 82 or self.subtype == 85 or self.subtype == 36353
-                )
-            else:
-                result = True if OldProtocol.true else False
-        elif isinstance(value, int):
-            result = bool(int)
-        else:
-            _LOGGER.error(
-                "Wrong data detected [old_protocol=%s], please update your customized configuration",
-                value,
-            )
-        return OldProtocol.true if result else OldProtocol.false
+        try:
+            if isinstance(value, str):
+                value = OldProtocol(value)
+            elif isinstance(value, int):
+                value = OldProtocol.true if value else OldProtocol.false
+            if not isinstance(value, OldProtocol):
+                raise ValueError("Invalid value for old_protocol")
+            return value
+        except ValueError as e:
+            _LOGGER.error(f"Invalid old_protocol value: {value}, error: {e}")
+            return self._default_old_protocol
 
     def build_query(self) -> list[MessageQuery]:
         return [MessageQuery(self._protocol_version)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `OldProtocol` enum with values `auto`, `true`, and `false`.
  - Enhanced the logic for handling old protocol settings.

- **Refactor**
  - Improved the `old_protocol` method, now `_normalize_old_protocol`, for better performance and reliability.
  - Updated the `set_customize` method to more robustly handle the `old_protocol` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->