### PR TITLE
build: skip no-commit-to-branch hook on CI

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         python-version: ["3.12", "3.11", "3.10"]
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-
+    env:
+      SKIP: no-commit-to-branch
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Python build workflow to include an environment variable `SKIP: no-commit-to-branch`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->