### PR TITLE
change the string of fan speed to be consistent with the constant from HA

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -64,12 +64,12 @@ class DeviceAttributes(StrEnum):
 
 class MideaACDevice(MideaDevice):
     _fresh_air_fan_speeds = {
-        0: "Off",
-        20: "Silent",
-        40: "Low",
-        60: "Medium",
-        80: "High",
-        100: "Full",
+        0: "off",
+        20: "silent",
+        40: "low",
+        60: "medium",
+        80: "high",
+        100: "full",
     }
     _fresh_air_fan_speeds_rev = dict(reversed(_fresh_air_fan_speeds.items()))
 
@@ -197,7 +197,7 @@ class MideaACDevice(MideaDevice):
                     else:
                         self._attributes[DeviceAttributes.fresh_air_mode] = v
             else:
-                self._attributes[DeviceAttributes.fresh_air_mode] = "Off"
+                self._attributes[DeviceAttributes.fresh_air_mode] = "off"
             new_status[DeviceAttributes.fresh_air_mode.value] = self._attributes[
                 DeviceAttributes.fresh_air_mode
             ]

--- a/midealocal/devices/cc/__init__.py
+++ b/midealocal/devices/cc/__init__.py
@@ -42,9 +42,9 @@ class MideaCCDevice(MideaDevice):
         0x10: "Level 5",
         0x20: "Level 6",
         0x40: "Level 7",
-        0x80: "Auto",
+        0x80: "auto",
     }
-    _fan_speeds_3level = {0x01: "Low", 0x08: "Medium", 0x40: "High", 0x80: "Auto"}
+    _fan_speeds_3level = {0x01: "low", 0x08: "medium", 0x40: "high", 0x80: "auto"}
 
     def __init__(
         self,

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -97,7 +97,7 @@ class TestMideaACDevice:
             mock_message.fresh_air_2 = 1
             self.device.process_message(bytearray())
 
-            self.device.set_attribute(DeviceAttributes.fresh_air_mode.value, "Medium")
+            self.device.set_attribute(DeviceAttributes.fresh_air_mode.value, "medium")
             mock_build_send.assert_called()
 
             self.device.set_attribute(DeviceAttributes.fresh_air_fan_speed.value, 50)
@@ -191,18 +191,18 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.current_energy_consumption.value] is None
             assert result[DeviceAttributes.realtime_power.value] is None
             assert result[DeviceAttributes.fresh_air_power.value]
-            assert result[DeviceAttributes.fresh_air_mode.value] == "Off"
+            assert result[DeviceAttributes.fresh_air_mode.value] == "off"
             assert result[DeviceAttributes.fresh_air_1.value] == 1
             assert result[DeviceAttributes.fresh_air_2.value] == 1
 
             mock_message.fresh_air_fan_speed = 55
             mock_message.fresh_air_1 = None
             result = self.device.process_message(bytearray())
-            assert result[DeviceAttributes.fresh_air_mode.value] == "Medium"
+            assert result[DeviceAttributes.fresh_air_mode.value] == "medium"
 
             mock_message.fresh_air_power = False
             result = self.device.process_message(bytearray())
-            assert result[DeviceAttributes.fresh_air_mode.value] == "Off"
+            assert result[DeviceAttributes.fresh_air_mode.value] == "off"
 
             mock_message.power = False
             result = self.device.process_message(bytearray())


### PR DESCRIPTION
wuwentao/midea_ac_lan#72

Only changed `AC` and `CC`.

No changes to `CC` devices with 7 levels

---

The modification seems safe, but I'm not very sure.