### PR TITLE
chore: fix ruff PGH003

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,7 @@ disallow_untyped_defs = true
 no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
+
+[mypy-tests.*]
+disallow_untyped_decorators = false
+

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -11,7 +11,7 @@ from midealocal.devices.a1.message import MessageQuery, MessageSet
 class TestMideaA1Device:
     """Test Midea A1 Device."""
 
-    @pytest.fixture(autouse=True)  # type: ignore
+    @pytest.fixture(autouse=True)
     def setup_device(self) -> None:
         """Midea A1 Device setup."""
         self.device = MideaA1Device(

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-
 from midealocal.devices.a1.message import (
     MessageA1Base,
     MessageA1Response,

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -18,7 +18,7 @@ class TestMideaACDevice:
 
     device: MideaACDevice
 
-    @pytest.fixture(autouse=True)  # type: ignore
+    @pytest.fixture(autouse=True)
     def setup_device(self) -> None:
         """Midea AC Device setup."""
         self.device = MideaACDevice(

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -335,7 +335,7 @@ class TestMessageGeneralSet:
 class TestMessageACResponse:
     """Test Message AC Response."""
 
-    @pytest.fixture(autouse=True)  # type: ignore
+    @pytest.fixture(autouse=True)
     def setup_header(self) -> None:
         """Setup header."""
         self.header = bytearray(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `mypy` configuration to allow untyped decorators in test files.
  - Removed unnecessary `# type: ignore` comments from several test fixtures for cleaner code.

- **Style**
  - Cleaned up import spacing in `message_a1_test.py`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->