### PR TITLE
feat: expose cloud servers

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -192,7 +192,7 @@ class MideaCloud:
         return result
 
     async def get_cloud_servers(self) -> dict[int, str]:
-        """Get available cloud servers from upstream library."""
+        """Get available cloud servers."""
         cloud_servers: dict[int, str] = {}
         for i, cloud in enumerate(clouds, start=1):
             cloud_servers[i] = cloud

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -191,6 +191,7 @@ class MideaCloud:
         result.update(default_keys)
         return result
 
+    @staticmethod
     async def get_cloud_servers(self) -> dict[int, str]:
         """Get available cloud servers."""
         cloud_servers: dict[int, str] = {}

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -192,7 +192,7 @@ class MideaCloud:
         return result
 
     @staticmethod
-    async def get_cloud_servers(self) -> dict[int, str]:
+    async def get_cloud_servers() -> dict[int, str]:
         """Get available cloud servers."""
         cloud_servers: dict[int, str] = {}
         for i, cloud in enumerate(clouds, start=1):

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -194,10 +194,8 @@ class MideaCloud:
     async def get_cloud_servers(self) -> dict[int, str]:
         """Get available cloud servers from upstream library."""
         cloud_servers: dict[int, str] = {}
-        i = 1
-        for cloud in clouds:
-            cloud_servers.update({i: cloud})
-            i = i + 1
+        for i, cloud in enumerate(clouds, start=1):
+            cloud_servers[i] = cloud
         return cloud_servers
 
     async def list_home(self) -> dict[int, Any] | None:

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -191,6 +191,15 @@ class MideaCloud:
         result.update(default_keys)
         return result
 
+    async def get_cloud_servers(self) -> dict[int, str]:
+        """Get available cloud servers from upstream library."""
+        cloud_servers: dict[int, str] = {}
+        i = 1
+        for cloud in clouds:
+            cloud_servers.update({i: cloud})
+            i = i + 1
+        return cloud_servers
+
     async def list_home(self) -> dict[int, Any] | None:
         return {1: "My home"}
 


### PR DESCRIPTION
Expose cloud servers list so Home Assistant components can grab them easily and avoid duplicating data.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to retrieve available cloud servers, enhancing the app's cloud management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->