### PR TITLE
rollback default value to previous result

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -138,7 +138,7 @@ class MideaDevice(threading.Thread):
         self._subtype = subtype
         self._protocol_version = 0
         self._updates: list[Callable[[dict[str, Any]], None]] = []
-        self._unsupported_protocol = [dict]
+        self._unsupported_protocol = []
         self._is_run = False
         self._available = True
         self._appliance_query = True

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -138,7 +138,7 @@ class MideaDevice(threading.Thread):
         self._subtype = subtype
         self._protocol_version = 0
         self._updates: list[Callable[[dict[str, Any]], None]] = []
-        self._unsupported_protocol = []
+        self._unsupported_protocol: list[str] = []
         self._is_run = False
         self._available = True
         self._appliance_query = True


### PR DESCRIPTION
still not fix the RefreshFailed() error.
rollback this option default value to previous result and continue check with it in new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Replaced an internal placeholder `[dict]` with an empty list `[]` to improve code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->