### PR TITLE
fix: allign set_target_temperature signatures (part2)

### DIFF
--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -290,11 +290,11 @@ class MideaC3Device(MideaDevice):
         self,
         target_temperature: float,
         mode: int | None,
-        zone: int,
+        zone: int | None = None,
     ) -> None:
         """Midea C3 device set target temperature."""
         message = self.make_message_set()
-        if self._attributes[DeviceAttributes.zone_temp_type][zone]:
+        if zone and self._attributes[DeviceAttributes.zone_temp_type][zone]:
             message.zone_target_temp[zone] = target_temperature
         else:
             message.room_target_temp = target_temperature

--- a/midealocal/devices/fb/__init__.py
+++ b/midealocal/devices/fb/__init__.py
@@ -112,6 +112,14 @@ class MideaFBDevice(MideaDevice):
             setattr(message, str(attr), value)
         self.build_send(message)
 
+    def set_target_temperature(
+        self,
+        target_temperature: float,
+        mode: int | None,
+        zone: int | None = None,
+    ) -> None:
+        """Midea FB device set target temperature."""
+
 
 class MideaAppliance(MideaFBDevice):
     """Midea FB appliance."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to set target temperature for Midea FB devices with optional mode and zone parameters.

- **Improvements**
	- Enhanced Midea C3 device temperature setting functionality by adding a default value for the zone parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->