### PR TITLE
feat: add set_target_temperature for MideaFBDevice

### DIFF
--- a/midealocal/devices/fb/__init__.py
+++ b/midealocal/devices/fb/__init__.py
@@ -115,10 +115,13 @@ class MideaFBDevice(MideaDevice):
     def set_target_temperature(
         self,
         target_temperature: float,
-        mode: int | None,
-        zone: int | None = None,
+        mode: int | None,  # noqa: ARG002
+        zone: int | None = None,  # noqa: ARG002
     ) -> None:
         """Midea FB device set target temperature."""
+        message = MessageSet(self._protocol_version, self.subtype)
+        setattr(message, DeviceAttributes.target_temperature, target_temperature)
+        self.build_send(message)
 
 
 class MideaAppliance(MideaFBDevice):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `set_target_temperature` method for better reliability and accuracy when setting the temperature on Midea FB devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->