### PR TITLE
build: improve devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,7 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT=3.11-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/python:1-3.11
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# Install Python dependencies from requirements
 COPY requirements*.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements-all.txt \
    && rm -rf /tmp/pip-tmp
@@ -17,5 +12,5 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install pre-commit
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+# Set the default shell to bash instead of sh
+ENV SHELL /bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,14 @@
 {
-  "name": "Python 3",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "..",
-    "args": {
-      "VARIANT": "3.11-bullseye"
-    }
+  "name": "Midea Local Dev",
+  "context": "..",
+  "dockerFile": "Dockerfile",
+  "postCreateCommand": "scripts/setup.sh",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
+  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
   "customizations": {
     "vscode": {
-      "settings": {
-        "editor.formatOnPaste": false,
-        "editor.formatOnSave": true,
-        "editor.formatOnType": true,
-        "python.formatting.provider": "charliermarsh.ruff",
-        "python.testing.pytestArgs": ["tests"],
-        "python.testing.pytestEnabled": true,
-        "python.testing.unittestEnabled": false,
-        "pylint.args": [],
-        "files.trimTrailingWhitespace": true
-      },
       "extensions": [
         "charliermarsh.ruff",
         "ms-python.pylint",
@@ -28,9 +17,26 @@
         "redhat.vscode-yaml",
         "esbenp.prettier-vscode",
         "GitHub.vscode-pull-request-github"
-      ]
+      ],
+      "settings": {
+        "python.experiments.optOutFrom": ["pythonTestAdapter"],
+        "python.terminal.activateEnvInCurrentTerminal": true,
+        "python.testing.pytestArgs": ["--no-cov"],
+        "pylint.importStrategy": "fromEnvironment",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
     }
-  },
-  "remoteUser": "vscode",
-  "postAttachCommand": "pre-commit install"
+  }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["--no-cov"],
+  "python.testing.pytestEnabled": false,
+  "pylint.importStrategy": "fromEnvironment"
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Setups the repository.
+
+# Stop on errors
+set -e
+
+pre-commit install


### PR DESCRIPTION
Tested both situations:

- rebuild from existing
- create from stretch



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration to recommend VS Code extensions: "charliermarsh.ruff", "esbenp.prettier-vscode", and "ms-python.python".
  - Introduced settings for Python testing with pytest and pylint import strategy.
  - Updated `setup.sh` to automate repository setup and install pre-commit hooks.

- **Enhancements**
  - Renamed development container to "Midea Local Dev" and updated Dockerfile context.
  - Set the default shell to bash for the development container.
  - Added GitHub CLI feature to the development container setup.

- **Refactor**
  - Adjusted VS Code settings for improved Python linting, formatting, and terminal configurations.
  - Simplified Dockerfile by removing unnecessary global node package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->