### PR TITLE
build(pre-commit.ci): disable local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ ci:
   autofix_commit_msg: "chore(pre-commit.ci): auto fixes"
   autoupdate_commit_msg: "chore(pre-commit.ci): pre-commit autoupdate"
   autoupdate_schedule: weekly
+  skip: [mypy]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Prerequisite to enable again [pre-commit.ci](https://pre-commit.ci/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit configuration to skip `mypy` checks in the CI process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->