### PR TITLE
fix: rollback get_keys with 3 keys

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -206,9 +206,8 @@ class MideaCloud:
                             "token": token["token"].lower(),
                             "key": token["key"].lower(),
                         }
-                break
-        if not result:
-            result.update(default_keys)
+        # add default key with method 1 and method 2 key
+        result.update(default_keys)
         return result
 
     @staticmethod

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -121,7 +121,12 @@ class CloudTest(IsolatedAsyncioTestCase):
         response = Mock()
         response.read = AsyncMock(
             side_effect=[
-                self.responses["meijucloud_get_keys.json"],
+                self.responses["meijucloud_get_keys1.json"],
+                self.responses["meijucloud_get_keys2.json"],
+                self.responses["meijucloud_get_keys1.json"],
+                self.responses["cloud_invalid_response.json"],
+                self.responses["cloud_invalid_response.json"],
+                self.responses["meijucloud_get_keys2.json"],
                 self.responses["cloud_invalid_response.json"],
                 self.responses["cloud_invalid_response.json"],
             ],
@@ -134,11 +139,36 @@ class CloudTest(IsolatedAsyncioTestCase):
             password="password",
         )
         assert cloud is not None
-        keys: dict = await cloud.get_keys(100)
-        assert keys[1]["token"] == "returnedappliancetoken"
-        assert keys[1]["key"] == "returnedappliancekey"
 
+        # test method1 + method2 + default key
+        keys3: dict = await cloud.get_keys(100)
+        # test response token/key
+        assert keys3[1]["token"] == "method1_return_token1"
+        assert keys3[1]["key"] == "method1_return_key1"
+        assert keys3[2]["token"] == "method2_return_token2"
+        assert keys3[2]["key"] == "method2_return_key2"
+        # simple test default key with length
+        assert len(keys3) == 3
+
+        # test method1 + default key
+        keys1: dict = await cloud.get_keys(100)
+        # test response token/key
+        assert keys1[1]["token"] == "method1_return_token1"
+        assert keys1[1]["key"] == "method1_return_key1"
+        # simple test default key with length
+        assert len(keys1) == 2
+
+        # test method2 + default key
+        keys2: dict = await cloud.get_keys(100)
+        # test response token/key
+        assert keys2[2]["token"] == "method2_return_token2"
+        assert keys2[2]["key"] == "method2_return_key2"
+        # simple test default key with length
+        assert len(keys2) == 2
+
+        # test only default key
         keys = await cloud.get_keys(100)
+        assert len(keys) == 1
         assert keys == default_keys
 
     async def test_meijucloud_list_home(self) -> None:

--- a/tests/responses/meijucloud_get_keys1.json
+++ b/tests/responses/meijucloud_get_keys1.json
@@ -4,8 +4,8 @@
     "tokenlist": [
       {
         "udpId": "dec4da86e0aeefadde14a4e553680b9b",
-        "token": "returnedappliancetoken",
-        "key": "returnedappliancekey"
+        "token": "method1_return_token1",
+        "key": "method1_return_key1"
       }
     ]
   }

--- a/tests/responses/meijucloud_get_keys2.json
+++ b/tests/responses/meijucloud_get_keys2.json
@@ -1,0 +1,12 @@
+{
+  "code": 0,
+  "data": {
+    "tokenlist": [
+      {
+        "udpId": "b2dd199071d527a33c8239833a5bf5fb",
+        "token": "method2_return_token2",
+        "key": "method2_return_key2"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
in current changes, get_keys will only return method 1 token/key and skip method 2 and default key.

in previous design, we should return 3 token/keys, and try with all the possible token/key.

use more token/key to retry always better than only check with one key.

so we need to rollback it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the `get_keys` functionality always updates with default keys, improving reliability of the feature.

- **Tests**
  - Expanded test coverage to include additional scenarios for `get_keys`, ensuring better validation and reliability.

- **Chores**
  - Updated JSON response files to align with new key naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->