### PR TITLE
chore: tag config of release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           token: ${{ secrets.MIDEA_GITHUB_PAT }}
           release-type: python
+          include-v-in-tag: true
+          tag-separator: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release workflow to include 'v' in tags for Python releases when the tag separator is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->