### PR TITLE
chore: revert tag config of release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,5 +17,3 @@ jobs:
         with:
           token: ${{ secrets.MIDEA_GITHUB_PAT }}
           release-type: python
-          include-v-in-tag: true
-          tag-separator: ""


### PR DESCRIPTION
I thought this would help version detection, but they are invalid parameter for v4. I did rename the tags and it worked.

Reverts rokam/midea-local#206