### PR TITLE
fix: wrong dependencies with package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-colorlog
+build
 mypy
 pytest
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles
 aiohttp
-build
+colorlog
 defusedxml
 ifaddr
 pycryptodome


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development dependencies: replaced `colorlog` with `build` in `requirements-dev.txt`.
	- Updated production dependencies: replaced `build` with `colorlog` in `requirements.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->