### PR TITLE
fix(capabilities): make capabilities optional

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -218,7 +218,7 @@ class MideaDevice(threading.Thread):
             if refresh_status:
                 self.refresh_status(wait_response=True)
             if get_capabilities:
-                self.get_capabilities(wait_response=True)
+                self.get_capabilities()
             connected = True
         except TimeoutError:
             _LOGGER.debug("[%s] Connection timed out", self._device_id)
@@ -292,41 +292,11 @@ class MideaDevice(threading.Thread):
         msg = PacketBuilder(self._device_id, data).finalize()
         self.send_message(msg)
 
-    def get_capabilities(self, wait_response: bool = False) -> None:
+    def get_capabilities(self) -> None:
         """Get device capabilities."""
         cmds: list = self.capabilities_query()
-        if self._appliance_query:
-            cmds = [MessageQueryAppliance(self.device_type), *cmds]
-        error_count = 0
         for cmd in cmds:
-            if cmd.__class__.__name__ not in self._unsupported_protocol:
-                self.build_send(cmd)
-                if wait_response:
-                    try:
-                        while True:
-                            if not self._socket:
-                                raise SocketException
-                            msg = self._socket.recv(512)
-                            if len(msg) == 0:
-                                raise OSError("Empty message received.")
-                            result = self.parse_message(msg)
-                            if result == ParseMessageResult.SUCCESS:
-                                break
-                            if result == ParseMessageResult.PADDING:
-                                continue
-                            error_count += 1
-                    except TimeoutError:
-                        error_count += 1
-                        self._unsupported_protocol.append(cmd.__class__.__name__)
-                        _LOGGER.debug(
-                            "[%s] Does not supports the protocol %s, ignored",
-                            self._device_id,
-                            cmd.__class__.__name__,
-                        )
-            else:
-                error_count += 1
-        if len(cmds) > 0 and error_count == len(cmds):
-            raise CapabilitiesFailed
+            self.build_send(cmd)
 
     def refresh_status(self, wait_response: bool = False) -> None:
         """Refresh device status."""

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -75,10 +75,6 @@ class AuthException(Exception):
     """Authentication exception."""
 
 
-class CapabilitiesFailed(Exception):
-    """Capabilities failed exception."""
-
-
 class ResponseException(Exception):
     """Response exception."""
 
@@ -228,8 +224,6 @@ class MideaDevice(threading.Thread):
             _LOGGER.debug("[%s] Authentication failed", self._device_id)
         except RefreshFailed:
             _LOGGER.debug("[%s] Refresh status is timed out", self._device_id)
-        except CapabilitiesFailed:
-            _LOGGER.debug("[%s] Refresh capabilities is timed out", self._device_id)
         except Exception as e:
             file = None
             lineno = None

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -8,7 +8,6 @@ import pytest
 from midealocal.cloud import default_keys
 from midealocal.device import (
     AuthException,
-    CapabilitiesFailed,
     MideaDevice,
     ParseMessageResult,
     ProtocolVersion,
@@ -77,7 +76,7 @@ class MideaDeviceTest(IsolatedAsyncioTestCase):
             patch.object(
                 self.device,
                 "get_capabilities",
-                side_effect=[CapabilitiesFailed(), None],
+                side_effect=[None, None],
             ),
         ):
             connect_mock.side_effect = [

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -66,17 +66,17 @@ class MideaDeviceTest(IsolatedAsyncioTestCase):
             patch.object(
                 self.device,
                 "authenticate",
-                side_effect=[AuthException(), None, None, None],
+                side_effect=[AuthException(), None, None],
             ),
             patch.object(
                 self.device,
                 "refresh_status",
-                side_effect=[RefreshFailed(), None, None],
+                side_effect=[RefreshFailed(), None],
             ),
             patch.object(
                 self.device,
                 "get_capabilities",
-                side_effect=[None, None],
+                side_effect=[None],
             ),
         ):
             connect_mock.side_effect = [
@@ -87,9 +87,6 @@ class MideaDeviceTest(IsolatedAsyncioTestCase):
                 None,
                 None,
             ]
-            assert self.device.connect(True, True) is False
-            assert self.device.available is False
-
             assert self.device.connect(True, True) is False
             assert self.device.available is False
 


### PR DESCRIPTION
With this change, if capabilities fail, no exception is thrown. So AC devices that doesn't support capabilities will remain working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved device connection process to streamline capability querying.

- **Refactor**
  - Simplified the `get_capabilities` method to focus on sending commands.

- **Tests**
  - Updated tests for capability querying to enhance clarity and remove redundant checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->