### PR TITLE
feat(c3): query and set silence level

### DIFF
--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -62,7 +62,7 @@ class MideaC3Device(MideaDevice):
                 DeviceAttributes.zone1_water_temp_mode: False,
                 DeviceAttributes.zone2_water_temp_mode: False,
                 DeviceAttributes.silent_mode: False,
-                DeviceAttributes.SILENT_LEVEL: C3SilentLevel.SILENT,
+                DeviceAttributes.SILENT_LEVEL: C3SilentLevel.OFF,
                 DeviceAttributes.eco_mode: False,
                 DeviceAttributes.tbh: False,
                 DeviceAttributes.mode: 1,
@@ -233,9 +233,19 @@ class MideaC3Device(MideaDevice):
         elif attr == DeviceAttributes.eco_mode:
             message = MessageSetECO(self._protocol_version)
             setattr(message, str(attr), value)
-        elif attr == DeviceAttributes.silent_mode:
+        elif attr in [
+            DeviceAttributes.silent_mode.value,
+            DeviceAttributes.SILENT_LEVEL.value,
+        ]:
             message = MessageSetSilent(self._protocol_version)
-            setattr(message, str(attr), value)
+            if attr == DeviceAttributes.silent_mode.value and isinstance(value, bool):
+                message.silent_mode = bool(value)
+                message.silent_level = (
+                    C3SilentLevel.SILENT if value else C3SilentLevel.OFF
+                )
+            elif attr == DeviceAttributes.SILENT_LEVEL.value and isinstance(value, int):
+                message.silent_level = C3SilentLevel(int(value))
+                message.silent_mode = value != C3SilentLevel.OFF
         if message is not None:
             self.build_send(message)
 

--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -10,6 +10,8 @@ from midealocal.devices.c3.const import C3DeviceMode, C3SilentLevel, DeviceAttri
 from .message import (
     MessageC3Response,
     MessageQuery,
+    MessageQueryBasic,
+    MessageQuerySilence,
     MessageSet,
     MessageSetECO,
     MessageSetSilent,
@@ -101,7 +103,10 @@ class MideaC3Device(MideaDevice):
 
     def build_query(self) -> list[MessageQuery]:
         """Midea C3 device build query."""
-        return [MessageQuery(self._protocol_version)]
+        return [
+            MessageQueryBasic(self._protocol_version),
+            MessageQuerySilence(self._protocol_version),
+        ]
 
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Midea C3 device process message."""

--- a/midealocal/devices/c3/message.py
+++ b/midealocal/devices/c3/message.py
@@ -37,17 +37,33 @@ class MessageC3Base(MessageRequest):
 class MessageQuery(MessageC3Base):
     """C3 message query."""
 
-    def __init__(self, protocol_version: int) -> None:
+    def __init__(self, protocol_version: int, body_type: BodyType) -> None:
         """Initialize C3 message query."""
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.query,
-            body_type=0x01,
+            body_type=body_type,
         )
 
     @property
     def _body(self) -> bytearray:
         return bytearray([])
+
+
+class MessageQueryBasic(MessageQuery):
+    """C3 Message query basic."""
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize C3 message query basic."""
+        super().__init__(protocol_version, BodyType.X01)
+
+
+class MessageQuerySilence(MessageQuery):
+    """C3 Message query silence."""
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize C3 message query silence."""
+        super().__init__(protocol_version, BodyType.X05)
 
 
 class MessageSet(MessageC3Base):
@@ -58,7 +74,7 @@ class MessageSet(MessageC3Base):
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
-            body_type=0x01,
+            body_type=BodyType.X01,
         )
         self.zone1_power = False
         self.zone2_power = False
@@ -109,7 +125,7 @@ class MessageSetSilent(MessageC3Base):
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
-            body_type=0x05,
+            body_type=BodyType.X05,
         )
         self.silent_mode = False
         self.silent_level = C3SilentLevel.OFF
@@ -139,7 +155,7 @@ class MessageSetECO(MessageC3Base):
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
-            body_type=0x07,
+            body_type=BodyType.X07,
         )
         self.eco_mode = False
 

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -9,7 +9,8 @@ from midealocal.devices.c3 import (
 )
 from midealocal.devices.c3.const import C3DeviceMode, C3SilentLevel, DeviceAttributes
 from midealocal.devices.c3.message import (
-    MessageQuery,
+    MessageQueryBasic,
+    MessageQuerySilence,
 )
 
 
@@ -109,8 +110,9 @@ class TestMideaC3Device:
     def test_build_query(self) -> None:
         """Test build query."""
         queries = self.device.build_query()
-        assert len(queries) == 1
-        assert isinstance(queries[0], MessageQuery)
+        assert len(queries) == 2
+        assert isinstance(queries[0], MessageQueryBasic)
+        assert isinstance(queries[1], MessageQuerySilence)
 
     def test_process_message(self) -> None:
         """Test process message."""

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -51,8 +51,7 @@ class TestMideaC3Device:
         assert self.device.attributes[DeviceAttributes.zone2_water_temp_mode] is False
         assert self.device.attributes[DeviceAttributes.silent_mode] is False
         assert (
-            self.device.attributes[DeviceAttributes.SILENT_LEVEL]
-            == C3SilentLevel.SILENT
+            self.device.attributes[DeviceAttributes.SILENT_LEVEL] == C3SilentLevel.OFF
         )
         assert self.device.attributes[DeviceAttributes.eco_mode] is False
         assert self.device.attributes[DeviceAttributes.tbh] is False
@@ -106,6 +105,11 @@ class TestMideaC3Device:
 
             self.device.set_attribute(DeviceAttributes.silent_mode.value, True)
             mock_build_send.assert_called()
+
+            self.device.set_attribute(
+                DeviceAttributes.SILENT_LEVEL.value,
+                C3SilentLevel.SILENT,
+            )
 
     def test_build_query(self) -> None:
         """Test build query."""

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -7,6 +7,8 @@ from midealocal.devices.c3.message import (
     MessageC3Base,
     MessageC3Response,
     MessageQuery,
+    MessageQueryBasic,
+    MessageQuerySilence,
     MessageSet,
     MessageSetECO,
     MessageSetSilent,
@@ -29,8 +31,12 @@ class TestC3MessageQuery:
 
     def test_query_body(self) -> None:
         """Test query body."""
-        msg = MessageQuery(protocol_version=1)
+        msg: MessageQuery = MessageQueryBasic(protocol_version=1)
         expected_body = bytearray([0x1])
+        assert msg.body == expected_body
+
+        msg = MessageQuerySilence(protocol_version=1)
+        expected_body = bytearray([0x5])
         assert msg.body == expected_body
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `MessageQueryBasic` and `MessageQuerySilence` classes for more detailed query handling in Midea C3 devices.

- **Bug Fixes**
  - Updated tests to ensure correct handling and validation of `MessageQueryBasic` and `MessageQuerySilence`.

- **Refactor**
  - Modified `build_query` method to return multiple query types instead of a single type to improve query accuracy and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->