### PR TITLE
fix(cloud): get default keys as static

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -213,7 +213,8 @@ class MideaCloud:
         """Authenticate."""
         raise NotImplementedError
 
-    async def get_default_keys(self) -> dict[int, dict[str, Any]]:
+    @staticmethod
+    async def get_default_keys() -> dict[int, dict[str, Any]]:
         """Get default cloud keys."""
         return DEFAULT_KEYS
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed `get_default_keys` methods in the `Cloud` class to static methods for improved code structure and behavior consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->