### PR TITLE
feat(cli): set attribute from device

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,21 @@
         "--device-sn",
         "${input:device-sn}"
       ]
+    },
+    {
+      "name": "Python Debugger: Set device attribute",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "midealocal.cli",
+      "args": [
+        "setattr",
+        "-d",
+        "${input:host}",
+        "${input:attribute}",
+        "${input:value}",
+        "--attr-type",
+        "${input:attr-type}"
+      ]
     }
   ],
   "inputs": [
@@ -99,6 +114,22 @@
       "type": "promptString",
       "password": true,
       "description": "Enter cloud password."
+    },
+    {
+      "id": "attribute",
+      "type": "promptString",
+      "description": "Enter attribute name."
+    },
+    {
+      "id": "value",
+      "type": "promptString",
+      "description": "Enter attribute value."
+    },
+    {
+      "id": "attr-type",
+      "type": "pickString",
+      "options": ["bool", "int", "str"],
+      "description": "Choose attribute type."
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new debugging configuration for setting device attributes in the Python application.
  - Added a command for setting attributes on discovered devices through the CLI, enhancing device management.
  
- **Bug Fixes**
  - Improved the device discovery process by allowing it to return a device object or `None`.

- **Tests**
  - Added an asynchronous test for validating the setting of device attributes in the CLI, improving test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->