### PR TITLE
chore: don't label release-please PRs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -16,6 +16,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   label-pr:
     runs-on: ubuntu-latest
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'autorelease') }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced control over the GitHub Actions workflow by adding a condition to the `label-pr` job, ensuring it only runs when the `autorelease` label is absent from the pull request.

- **Chores**
  - Updated workflow configurations for better efficiency and control in pull request label management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->