### PR TITLE
fix(cli): authenticate to get keys

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -55,8 +55,14 @@ class MideaCLI:
 
     async def _get_keys(self, device_id: int) -> dict[int, dict[str, Any]]:
         cloud = await self._get_cloud()
-        cloud_keys = await cloud.get_cloud_keys(device_id)
         default_keys = await cloud.get_default_keys()
+        if not await cloud.login():
+            _LOGGER.warning(
+                "Failed to authenticate to the cloud. Using only default keys.",
+            )
+            return default_keys
+        cloud_keys = await cloud.get_cloud_keys(device_id)
+
         return {**cloud_keys, **default_keys}
 
     async def discover(self) -> MideaDevice | None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication logic for cloud key retrieval to ensure valid session checks before accessing device-specific keys.
  
- **Bug Fixes**
	- Improved error handling to prevent attempts to access cloud keys when authentication fails, reducing potential API misuse.

- **Tests**
	- Added an asynchronous test for `_get_keys` to validate key retrieval and caching behavior under various scenarios, improving overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->