### PR TITLE
fix(c3): silent typo

### DIFF
--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -23,11 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 class MideaC3Device(MideaDevice):
     """Midea C3 device."""
 
-    _silent_modes: ClassVar[dict[int, str]] = {
-        C3SilentLevel.OFF.value: C3SilentLevel.OFF.name,
-        C3SilentLevel.SILENT.value: C3SilentLevel.SILENT.name,
-        C3SilentLevel.SUPER_SILENT.value: C3SilentLevel.SUPER_SILENT.name,
-    }
+    _silent_modes: ClassVar[list[str]] = [
+        C3SilentLevel.OFF.name,
+        C3SilentLevel.SILENT.name,
+        C3SilentLevel.SUPER_SILENT.name,
+    ]
 
     def __init__(
         self,
@@ -106,6 +106,11 @@ class MideaC3Device(MideaDevice):
     def temperature_step(self) -> float | None:
         """Midea C3 device temperature step."""
         return self._temperature_step
+
+    @property
+    def silent_modes(self) -> list[str]:
+        """Midea C3 device silent modes."""
+        return MideaC3Device._silent_modes
 
     def build_query(self) -> list[MessageQuery]:
         """Midea C3 device build query."""
@@ -249,9 +254,9 @@ class MideaC3Device(MideaDevice):
                 message.silent_level = (
                     C3SilentLevel.SILENT if value else C3SilentLevel.OFF
                 )
-            elif attr == DeviceAttributes.SILENT_LEVEL.value and isinstance(value, int):
-                message.silent_level = C3SilentLevel(int(value))
-                message.silent_mode = value != C3SilentLevel.OFF
+            elif attr == DeviceAttributes.SILENT_LEVEL.value and isinstance(value, str):
+                message.silent_level = C3SilentLevel[value]
+                message.silent_mode = value != C3SilentLevel.OFF.name
         if message is not None:
             self.build_send(message)
 

--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any
+from typing import Any, ClassVar
 
 from midealocal.device import MideaDevice
 from midealocal.devices.c3.const import C3DeviceMode, C3SilentLevel, DeviceAttributes
@@ -22,6 +22,12 @@ _LOGGER = logging.getLogger(__name__)
 
 class MideaC3Device(MideaDevice):
     """Midea C3 device."""
+
+    _silent_modes: ClassVar[dict[int, str]] = {
+        C3SilentLevel.OFF.value: C3SilentLevel.OFF.name,
+        C3SilentLevel.SILENT.value: C3SilentLevel.SILENT.name,
+        C3SilentLevel.SUPER_SILENT.value: C3SilentLevel.SUPER_SILENT.name,
+    }
 
     def __init__(
         self,

--- a/midealocal/devices/c3/message.py
+++ b/midealocal/devices/c3/message.py
@@ -240,10 +240,10 @@ class C3QuerySilenceMessageBody(MessageBody):
     def __init__(self, body: bytearray, data_offset: int = 0) -> None:
         """Initialize C3 notify1 message body."""
         super().__init__(body)
-        self.silence_mode = body[data_offset] & 0x1 > 0
-        self.silence_level = (
+        self.silent_mode = body[data_offset] & 0x1 > 0
+        self.silent_level = (
             (body[data_offset] & 0x1) + ((body[data_offset] & 0x8) >> 2)
-            if self.silence_mode
+            if self.silent_mode
             else C3SilentLevel.OFF
         )
         # Message protocol information:

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -90,6 +90,7 @@ class TestMideaC3Device:
         assert self.device.attributes[DeviceAttributes.outdoor_temperature] is None
         assert self.device.attributes[DeviceAttributes.error_code] == 0
         assert self.device.temperature_step == 1
+        assert len(self.device.silent_modes) == 3
 
     def test_set_attribute(self) -> None:
         """Test set attribute."""

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -108,7 +108,7 @@ class TestMideaC3Device:
 
             self.device.set_attribute(
                 DeviceAttributes.SILENT_LEVEL.value,
-                C3SilentLevel.SILENT,
+                C3SilentLevel.SILENT.name,
             )
 
     def test_build_query(self) -> None:

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -291,28 +291,28 @@ class TestMessageC3Response:
             ],
         )
         response = MessageC3Response(self.header + body)
-        assert hasattr(response, "silence_mode")
-        assert response.silence_mode is False
-        assert hasattr(response, "silence_level")
-        assert response.silence_level == C3SilentLevel.OFF
+        assert hasattr(response, "silent_mode")
+        assert response.silent_mode is False
+        assert hasattr(response, "silent_level")
+        assert response.silent_level == C3SilentLevel.OFF
 
         body[1] = 0x1
         response = MessageC3Response(self.header + body)
-        assert hasattr(response, "silence_mode")
-        assert response.silence_mode is True
-        assert hasattr(response, "silence_level")
-        assert response.silence_level == C3SilentLevel.SILENT
+        assert hasattr(response, "silent_mode")
+        assert response.silent_mode is True
+        assert hasattr(response, "silent_level")
+        assert response.silent_level == C3SilentLevel.SILENT
 
         body[1] = 0x8
         response = MessageC3Response(self.header + body)
-        assert hasattr(response, "silence_mode")
-        assert response.silence_mode is False
-        assert hasattr(response, "silence_level")
-        assert response.silence_level == C3SilentLevel.OFF
+        assert hasattr(response, "silent_mode")
+        assert response.silent_mode is False
+        assert hasattr(response, "silent_level")
+        assert response.silent_level == C3SilentLevel.OFF
 
         body[1] = 0x9
         response = MessageC3Response(self.header + body)
-        assert hasattr(response, "silence_mode")
-        assert response.silence_mode is True
-        assert hasattr(response, "silence_level")
-        assert response.silence_level == C3SilentLevel.SUPER_SILENT
+        assert hasattr(response, "silent_mode")
+        assert response.silent_mode is True
+        assert hasattr(response, "silent_level")
+        assert response.silent_level == C3SilentLevel.SUPER_SILENT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new class variable in the MideaC3Device to provide structured access to silent modes, enhancing usability.
	- Updated terminology for clarity by renaming `silence_mode` to `silent_mode` and `silence_level` to `silent_level`.

- **Tests**
	- Adjusted test cases to reflect the new attribute names for consistency and clarity.
	- Added verification to ensure the `silent_modes` attribute is initialized correctly with the expected number of modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->