### PR TITLE
fix(cli): discover must return a list

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -116,7 +116,6 @@ class MideaCLI:
                         device_list.append(dev)
         return device_list
 
-
     def message(self) -> None:
         """Load message into device."""
         device_type = int(self.namespace.message[2])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced device discovery functionality now supports returning multiple discovered devices.

- **Bug Fixes**
  - Improved error handling during device discovery by returning an empty list instead of `None` when no devices are found.

- **Improvements**
  - The `set_attribute` method updated to work seamlessly with the new device discovery process, ensuring robust device management. 

- **Tests**
  - Expanded test coverage for device discovery and attribute setting, enhancing validation for various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->