### PR TITLE
fix: body_type default value is zero and not None

### DIFF
--- a/midealocal/devices/e6/message.py
+++ b/midealocal/devices/e6/message.py
@@ -1,7 +1,7 @@
 """Midea local E6 message."""
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     MessageBody,
     MessageRequest,
     MessageResponse,
@@ -18,7 +18,7 @@ class MessageE6Base(MessageRequest):
             device_type=0xE6,
             protocol_version=protocol_version,
             message_type=message_type,
-            body_type=NONE_VALUE,
+            body_type=ZERO_VALUE,
         )
 
     @property

--- a/midealocal/devices/ea/message.py
+++ b/midealocal/devices/ea/message.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     MessageBody,
     MessageRequest,
     MessageResponse,
@@ -26,7 +26,7 @@ class MessageEABase(MessageRequest):
         self,
         protocol_version: int,
         message_type: int,
-        body_type: int = NONE_VALUE,
+        body_type: int = ZERO_VALUE,
     ) -> None:
         """Initialize EA message base."""
         super().__init__(

--- a/midealocal/devices/ec/message.py
+++ b/midealocal/devices/ec/message.py
@@ -1,7 +1,7 @@
 """Midea local EC message."""
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     MessageBody,
     MessageRequest,
     MessageResponse,
@@ -17,7 +17,7 @@ class MessageECBase(MessageRequest):
         self,
         protocol_version: int,
         message_type: int,
-        body_type: int = NONE_VALUE,
+        body_type: int = ZERO_VALUE,
     ) -> None:
         """Initialize EC message base."""
         super().__init__(

--- a/midealocal/devices/ed/message.py
+++ b/midealocal/devices/ed/message.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     BodyType,
     MessageBody,
     MessageRequest,
@@ -46,7 +46,7 @@ class MessageEDBase(MessageRequest):
         self,
         protocol_version: int,
         message_type: int,
-        body_type: int = NONE_VALUE,
+        body_type: int = ZERO_VALUE,
     ) -> None:
         """Initialize ED message base."""
         super().__init__(

--- a/midealocal/devices/fa/message.py
+++ b/midealocal/devices/fa/message.py
@@ -1,7 +1,7 @@
 """Midea local FA message."""
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     MessageBody,
     MessageRequest,
     MessageResponse,
@@ -21,7 +21,7 @@ class MessageFABase(MessageRequest):
         self,
         protocol_version: int,
         message_type: int,
-        body_type: int = NONE_VALUE,
+        body_type: int = ZERO_VALUE,
     ) -> None:
         """Initialize the message with protocol version, message type, and body type."""
         super().__init__(
@@ -64,7 +64,7 @@ class MessageSet(MessageFABase):
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
-            body_type=0x00,
+            body_type=ZERO_VALUE,
         )
         self._subtype = subtype
         self.power: bool | None = None

--- a/midealocal/devices/fb/message.py
+++ b/midealocal/devices/fb/message.py
@@ -1,7 +1,7 @@
 """Midea local FB message."""
 
 from midealocal.message import (
-    NONE_VALUE,
+    ZERO_VALUE,
     MessageBody,
     MessageRequest,
     MessageResponse,
@@ -24,7 +24,7 @@ class MessageFBBase(MessageRequest):
         self,
         protocol_version: int,
         message_type: int,
-        body_type: int = NONE_VALUE,
+        body_type: int = ZERO_VALUE,
     ) -> None:
         """Initialize FB message base."""
         super().__init__(

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -103,7 +103,7 @@ class MessageType(IntEnum):
     query_appliance = 0xA0
 
 
-NONE_VALUE = 0x00
+ZERO_VALUE = 0x00
 
 
 class MessageBase:
@@ -113,10 +113,10 @@ class MessageBase:
 
     def __init__(self) -> None:
         """Initialize message base."""
-        self._device_type = NONE_VALUE
-        self._message_type = NONE_VALUE
-        self._body_type = NONE_VALUE
-        self._protocol_version = NONE_VALUE
+        self._device_type = ZERO_VALUE
+        self._message_type = ZERO_VALUE
+        self._body_type = ZERO_VALUE
+        self._protocol_version = ZERO_VALUE
 
     @staticmethod
     def checksum(data: bytes) -> SupportsIndex:
@@ -177,7 +177,7 @@ class MessageBase:
             "message type": f".{f'{self.message_type:02x}'}",
             "body type": (
                 f".{f'{self._body_type:02x}'}"
-                if self._body_type != NONE_VALUE
+                if self._body_type is not None
                 else "None"
             ),
         }
@@ -237,7 +237,7 @@ class MessageRequest(MessageBase):
     def body(self) -> bytearray:
         """Message body."""
         body = bytearray([])
-        if self.body_type != NONE_VALUE:
+        if self.body_type is not None:
             body.append(self.body_type)
         if self._body is not None:
             body.extend(self._body)
@@ -265,7 +265,7 @@ class MessageQuestCustom(MessageRequest):
             device_type=device_type,
             protocol_version=protocol_version,
             message_type=cmd_type,
-            body_type=NONE_VALUE,
+            body_type=ZERO_VALUE,
         )
         self._cmd_body = cmd_body
 
@@ -288,7 +288,7 @@ class MessageQueryAppliance(MessageRequest):
             device_type=device_type,
             protocol_version=0,
             message_type=MessageType.query_appliance,
-            body_type=NONE_VALUE,
+            body_type=ZERO_VALUE,
         )
 
     @property


### PR DESCRIPTION
sorry for the delay to fix this bug, 
it should fix https://github.com/wuwentao/midea_ac_lan/issues/176 and some other devies issue for boy_type value error when control devices.

root cause from the debug log, just use power on device as example, **all the control message should be error** after this changes:

current issue summary from the issue debug log:  
from `v0.4.1` to `v0.4.2` changes the `body_type` default value check condition casued this issue(the latest version is the same as v0.4.2)

from the debug log we can found the issue root cause is :
`v0.4.1`:  `0000000001000000800000000000ff00000000`
`v0.4.2`: `00000001000000800000000000ff00000000`

> `v0.4.2` missed `00` in  body message, after checked the source code, I found it should be `body_type` , and the default value should be `0x00`:

midea_ac_lan `v0.4.1` using midealocal `v1.0.3`
midea_ac_lan `v0.4.2` using midealocal `v1.1.2`

code changes: 
in midealocal `v1.0.3`:  https://github.com/rokam/midea-local/blob/46350f511ee0beceed8f8fb18be36a9f91378714/midealocal/message.py#L36

after changes to `v1.1.2`:
https://github.com/rokam/midea-local/blob/2f53134cd051cac3ed69162878ce3846c14cbfba/midealocal/message.py#L117

so the default value chaged from `00` to `NONE`:
in `v1.0.3`: https://github.com/rokam/midea-local/blob/46350f511ee0beceed8f8fb18be36a9f91378714/midealocal/message.py#L137

in `v1.1.2`: https://github.com/rokam/midea-local/blob/2f53134cd051cac3ed69162878ce3846c14cbfba/midealocal/message.py#L239

original code is `if self.body_type is not None:`
and after changes is `if self.body_type != NONE_VALUE:`

so there is no **body_type** default value `0x00` append to the body message and causes this issue.

as this is a global message func,  just rollback the code changes and it should append the body_type `0x00` to body message.
in addition, also rename the `NONE_VALUE` to `ZERO_VALUE` as it's not none value, it should be zero value and still need to append to body message.

please help to review and double confirm it.

Thanks





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default value for the `body_type` parameter across multiple message classes from `NONE_VALUE` to `ZERO_VALUE`, enhancing clarity on how message body types are initialized.

- **Bug Fixes**
  - Improved consistency in message handling by standardizing the representation of default values within the Message classes, potentially reducing issues related to uninitialized states.

- **Documentation**
  - Clarified the intended use of the default value in the message initialization process, providing better understanding for developers working with message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->