### PR TITLE
fix(cloud): meiju cloud download_lua appliance_type error

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -515,7 +515,7 @@ class MeijuCloud(MideaCloud):
         """Download lua integration."""
         data = {
             "applianceSn": sn,
-            "applianceType": f".{f'x{device_type:02x}'}",
+            "applianceType": hex(device_type),
             "applianceMFCode": manufacturer_code,
             "version": "0",
             "iotAppId": self._app_id,


### PR DESCRIPTION
meiju cloud download_lua appliance_type error, just copy the same arg from msmart cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified the construction of the `applianceType` value for downloads, enhancing clarity and potential compatibility with downstream processes.

- **Impact**
  - The change may affect how the `applianceType` is interpreted, ensuring better consistency in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->