### PR TITLE
fix: ed device power/lock return message set and body_type 0x15 parse

### DIFF
--- a/midealocal/devices/ed/message.py
+++ b/midealocal/devices/ed/message.py
@@ -85,7 +85,7 @@ class MessageNewSet(MessageEDBase):
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.set,
-            body_type=0x15,
+            body_type=BodyType.X15,
         )
         self.power: bool | None = None
         self.lock: bool | None = None
@@ -244,9 +244,13 @@ class MessageEDResponse(MessageResponse):
     def __init__(self, message: bytes) -> None:
         """Initialize ED message response."""
         super().__init__(bytearray(message))
-        if self._message_type in [MessageType.query, MessageType.notify1]:
+        if self._message_type in [
+            MessageType.set,
+            MessageType.query,
+            MessageType.notify1,
+        ]:
             self.device_class = self._body_type
-            if self._body_type in [BodyType.X00, BodyType.FF]:
+            if self._body_type in [BodyType.X00, BodyType.X15, BodyType.FF]:
                 self.set_body(EDMessageBodyFF(super().body))
             if self.body_type == BodyType.X01:
                 self.set_body(EDMessageBody01(super().body))

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -32,6 +32,7 @@ class BodyType(IntEnum):
     X07 = 0x07
     X0A = 0x0A
     X11 = 0x11
+    X15 = 0x15
     X21 = 0x21
     X22 = 0x22
     X24 = 0x24

--- a/tests/devices/ed/__init__.py
+++ b/tests/devices/ed/__init__.py
@@ -1,0 +1,1 @@
+"""Midea local ED device tests."""

--- a/tests/devices/ed/device_ed_test.py
+++ b/tests/devices/ed/device_ed_test.py
@@ -1,0 +1,101 @@
+"""Test ED Device."""
+
+from unittest.mock import patch
+
+import pytest
+
+from midealocal.devices.ed import DeviceAttributes, MideaEDDevice
+from midealocal.devices.ed.message import MessageQuery
+
+
+class TestMideaEDDevice:
+    """Test Midea ED Device."""
+
+    device: MideaEDDevice
+
+    @pytest.fixture(autouse=True)
+    def _setup_device(self) -> None:
+        """Midea ed Device setup."""
+        self.device = MideaEDDevice(
+            name="Test Device",
+            device_id=1,
+            ip_address="192.168.1.100",
+            port=6444,
+            token="AA",
+            key="BB",
+            protocol=3,
+            model="test_model",
+            subtype=1,
+            customize="test_customize",
+        )
+
+    def test_initial_attributes(self) -> None:
+        """Test initial attributes."""
+        assert not self.device.attributes[DeviceAttributes.power]
+        assert self.device.attributes[DeviceAttributes.water_consumption] is None
+        assert self.device.attributes[DeviceAttributes.in_tds] is None
+        assert self.device.attributes[DeviceAttributes.out_tds] is None
+        assert self.device.attributes[DeviceAttributes.filter1] is None
+        assert self.device.attributes[DeviceAttributes.filter2] is None
+        assert self.device.attributes[DeviceAttributes.filter3] is None
+        assert self.device.attributes[DeviceAttributes.life1] is None
+        assert self.device.attributes[DeviceAttributes.life2] is None
+        assert self.device.attributes[DeviceAttributes.life3] is None
+        assert not self.device.attributes[DeviceAttributes.child_lock]
+
+    def test_process_message(self) -> None:
+        """Test process message."""
+        with patch("midealocal.devices.ed.MessageEDResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.protocol_version = 3
+            mock_message.power = True
+            mock_message.water_consumption = 123
+            mock_message.in_tds = 200
+            mock_message.out_tds = 5
+            mock_message.filter1 = 30
+            mock_message.filter2 = 20
+            mock_message.filter3 = 10
+            mock_message.life1 = 2
+            mock_message.life2 = 3
+            mock_message.life3 = 4
+            mock_message.child_lock = True
+            new_status = self.device.process_message(b"")
+            assert new_status[DeviceAttributes.power.value]
+            assert new_status[DeviceAttributes.water_consumption.value] == 123
+            assert new_status[DeviceAttributes.in_tds.value] == 200
+            assert new_status[DeviceAttributes.out_tds.value] == 5
+            assert new_status[DeviceAttributes.filter1.value] == 30
+            assert new_status[DeviceAttributes.filter2.value] == 20
+            assert new_status[DeviceAttributes.filter3.value] == 10
+            assert new_status[DeviceAttributes.life1.value] == 2
+            assert new_status[DeviceAttributes.life2.value] == 3
+            assert new_status[DeviceAttributes.life3.value] == 4
+
+            mock_message.child_lock = False
+            mock_message.water_consumption = 456
+            mock_message.in_tds = 300
+            mock_message.out_tds = 15
+            mock_message.filter1 = 15
+            mock_message.life3 = 15
+            new_status = self.device.process_message(b"")
+            assert not new_status[DeviceAttributes.child_lock.value]
+            assert new_status[DeviceAttributes.water_consumption.value] == 456
+            assert new_status[DeviceAttributes.in_tds.value] == 300
+            assert new_status[DeviceAttributes.out_tds.value] == 15
+            assert new_status[DeviceAttributes.filter1.value] == 15
+            assert new_status[DeviceAttributes.life3.value] == 15
+
+    def test_build_query(self) -> None:
+        """Test build query."""
+        queries = self.device.build_query()
+        assert len(queries) == 1
+        assert isinstance(queries[0], MessageQuery)
+
+    def test_set_attribute(self) -> None:
+        """Test set attribute."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.power, True)
+            mock_build_send.assert_called_once()
+
+            self.device.set_attribute(DeviceAttributes.child_lock, True)
+            mock_build_send.assert_called()

--- a/tests/devices/ed/message_ed_test.py
+++ b/tests/devices/ed/message_ed_test.py
@@ -1,0 +1,353 @@
+"""Test ED message."""
+
+import pytest
+
+from midealocal.devices.ed.message import (
+    EDMessageBody01,
+    EDMessageBody03,
+    EDMessageBody05,
+    EDMessageBody06,
+    EDMessageBody07,
+    EDMessageBodyFF,
+    MessageEDBase,
+    MessageEDResponse,
+    MessageNewSet,
+    MessageQuery,
+)
+
+
+class TestMessageEDBase:
+    """Test ED Message Base."""
+
+    def test_body_not_implemented(self) -> None:
+        """Test body not implemented."""
+        msg = MessageEDBase(protocol_version=1, message_type=1, body_type=1)
+        with pytest.raises(NotImplementedError):
+            _ = msg.body
+
+
+class TestMessageQuery:
+    """Test Message Query."""
+
+    def test_query_body(self) -> None:
+        """Test query body."""
+        query = MessageQuery(protocol_version=1, body_type=2)
+        expected_body = bytearray([0x02, 0x01])
+        assert query.body == expected_body
+
+
+class TestMessageNewSet:
+    """Test MessageNewSet."""
+
+    def test_message_newset(self) -> None:
+        """Test MessageNewSet."""
+        new_set = MessageNewSet(protocol_version=1)
+        expected_body = bytearray([0x15, 0x01, 0x00])
+        assert new_set.body == expected_body
+        new_set.power = True
+        expected_body = bytearray([0x15, 0x01, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00])
+        assert new_set.body == expected_body
+        new_set.lock = True
+        expected_body = bytearray(
+            [
+                0x15,
+                0x01,
+                0x02,
+                0x00,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x01,
+                0x02,
+                0x01,
+                0x00,
+                0x00,
+            ],
+        )
+        assert new_set.body == expected_body
+        new_set.power = None
+        expected_body = bytearray([0x15, 0x01, 0x01, 0x01, 0x02, 0x01, 0x00, 0x00])
+        assert new_set.body == expected_body
+
+
+class TestEDMessageBody01:
+    """Test EDMessageBody01."""
+
+    def test_ed_message01(self) -> None:
+        """Test EDMessageBody01."""
+        body = bytearray(40)
+        body[0] = 0x01  # Body Type
+        body[2] = 1  # Set power to True
+        body[7] = 2  # Set water_consumption bit1
+        body[8] = 3  # Set water_consumption bit2
+        body[36] = 4  # Set in_tds bit1
+        body[37] = 5  # Set in_tds bit2
+        body[38] = 6  # Set out_tds bit1
+        body[39] = 7  # Set out_tds bit2
+        body[15] = 7  # Set child_lock
+        body[25] = 4  # Set filter1 bit1
+        body[26] = 5  # Set filter1 bit2
+        body[27] = 5  # Set filter2 bit1
+        body[28] = 6  # Set filter2 bit2
+        body[29] = 6  # Set filter3 bit1
+        body[30] = 7  # Set filter3 bit2
+        body[16] = 2  # Set life1
+        body[17] = 3  # Set life2
+        body[18] = 4  # Set life3
+        message = EDMessageBody01(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 1
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 770
+        assert hasattr(message, "in_tds")
+        assert message.in_tds == 1284
+        assert hasattr(message, "out_tds")
+        assert message.out_tds == 1798
+        assert hasattr(message, "child_lock")
+        assert message.child_lock
+        assert hasattr(message, "filter1")
+        assert message.filter1 == 54
+        assert hasattr(message, "filter2")
+        assert message.filter2 == 64
+        assert hasattr(message, "filter3")
+        assert message.filter3 == 75
+        assert hasattr(message, "life1")
+        assert message.life1 == 2
+        assert hasattr(message, "life2")
+        assert message.life2 == 3
+        assert hasattr(message, "life3")
+        assert message.life3 == 4
+
+
+class TestEDMessageBody03:
+    """Test EDMessageBody03."""
+
+    def test_ed_message03(self) -> None:
+        """Test EDMessageBody03."""
+        body = bytearray(52)
+        body[0] = 0x03  # Body Type
+        body[51] = 1  # Set power to True
+        body[20] = 2  # Set water_consumption bit1
+        body[21] = 3  # Set water_consumption bit2
+        body[27] = 4  # Set in_tds bit1
+        body[28] = 5  # Set in_tds bit2
+        body[29] = 6  # Set out_tds bit1
+        body[30] = 7  # Set out_tds bit2
+        body[22] = 2  # Set life1
+        body[23] = 3  # Set life2
+        body[24] = 4  # Set life3
+        message = EDMessageBody03(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 3
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 770
+        assert hasattr(message, "in_tds")
+        assert message.in_tds == 1284
+        assert hasattr(message, "out_tds")
+        assert message.out_tds == 1798
+        assert hasattr(message, "child_lock")
+        assert not message.child_lock
+        assert hasattr(message, "life1")
+        assert message.life1 == 2
+        assert hasattr(message, "life2")
+        assert message.life2 == 3
+        assert hasattr(message, "life3")
+        assert message.life3 == 4
+
+
+class TestEDMessageBody05:
+    """Test EDMessageBody05."""
+
+    def test_ed_message05(self) -> None:
+        """Test EDMessageBody05."""
+        body = bytearray(52)
+        body[0] = 0x05  # Body Type
+        body[51] = 1  # Set power to True
+        body[20] = 2  # Set water_consumption bit1
+        body[21] = 3  # Set water_consumption bit2
+        message = EDMessageBody05(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 5
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 770
+        assert hasattr(message, "child_lock")
+        assert not message.child_lock
+
+
+class TestEDMessageBody06:
+    """Test EDMessageBody06."""
+
+    def test_ed_message06(self) -> None:
+        """Test EDMessageBody06."""
+        body = bytearray(52)
+        body[0] = 0x06  # Body Type
+        body[51] = 1  # Set power to True
+        body[25] = 2  # Set water_consumption bit1
+        body[26] = 3  # Set water_consumption bit2
+        message = EDMessageBody06(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 6
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 770
+        assert hasattr(message, "child_lock")
+        assert not message.child_lock
+
+
+class TestEDMessageBody07:
+    """Test EDMessageBody07."""
+
+    def test_ed_message07(self) -> None:
+        """Test EDMessageBody07."""
+        body = bytearray(52)
+        body[0] = 0x07  # Body Type
+        body[51] = 1  # Set power to True
+        body[20] = 2  # Set water_consumption bit1
+        body[21] = 3  # Set water_consumption bit2
+        message = EDMessageBody07(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 7
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 770
+        assert hasattr(message, "child_lock")
+        assert not message.child_lock
+
+
+class TestEDMessageBodyFF:
+    """Test EDMessageBodyFF."""
+
+    def test_ed_message_ff(self) -> None:
+        """Test EDMessageBodyFF."""
+        body = bytearray(
+            [
+                0xFF,  # body_type
+                0x01,
+                0x07,  # category
+                0x00,  # part 1, offset+1,  attr bit1, test 0x00/CHILD_LOCK
+                0x40,  # part 1, offset+2,  attr bit2 and length bit
+                0x00,  # part 1, offset+3,
+                0x00,  # part 1, offset+4,
+                0x01,  # part 1, offset+5, child_lock
+                0x01,  # part 1, offset+6, power
+                0x10,  # part 2, offset+1,  attr bit1, test 0x10/LIFE
+                0x40,  # part 2, offset+2,  attr bit2 and length bit
+                0x01,  # part 2, offset+3, life1
+                0x02,  # part 2, offset+4, life2
+                0x03,  # part 2, offset+5, life3
+                0x00,  # part 2,
+                0x11,  # part 3, offset+1,  attr bit1, test 0x11/WATER_CONSUMPTION
+                0x40,  # part 3, offset+2,  attr bit2 and length bit
+                0x01,  # part 3, offset+3, water_consumption bit1
+                0x02,  # part 3, offset+4, water_consumption bit2
+                0x03,  # part 3, offset+5, water_consumption bit3
+                0x04,  # part 3, offset+6, water_consumption bit4
+                0x13,  # part 4, offset+1,  attr bit1, test 0x13/TDS
+                0x40,  # part 4, offset+2,  attr bit2 and length bit
+                0x04,  # part 4, offset+3, in_tds bit1
+                0x03,  # part 4, offset+4, in_tds bit2
+                0x02,  # part 4, offset+5, out_tds bit1
+                0x01,  # part 4, offset+6, out_tds bit2
+            ],
+        )
+
+        message = EDMessageBodyFF(body=body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 255
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 67305.985
+        assert hasattr(message, "in_tds")
+        assert message.in_tds == 772
+        assert hasattr(message, "out_tds")
+        assert message.out_tds == 258
+        assert hasattr(message, "child_lock")
+        assert message.child_lock
+        assert hasattr(message, "life1")
+        assert message.life1 == 1
+        assert hasattr(message, "life2")
+        assert message.life2 == 2
+        assert hasattr(message, "life3")
+        assert message.life3 == 3
+
+
+class TestMessageEDResponse:
+    """Test Message ED Response."""
+
+    def test_ed_general_response(self) -> None:
+        """Test general response."""
+        header = bytearray(
+            [
+                0xAA,
+                0x00,
+                0xDA,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x03,
+            ],
+        )
+        body = bytearray(
+            [
+                0xFF,  # body_type
+                0x01,
+                0x07,  # category
+                0x00,  # part 1, offset+1,  attr bit1, test 0x00/CHILD_LOCK
+                0x40,  # part 1, offset+2,  attr bit2 and length bit
+                0x00,  # part 1, offset+3,
+                0x00,  # part 1, offset+4,
+                0x01,  # part 1, offset+5, child_lock
+                0x01,  # part 1, offset+6, power
+                0x10,  # part 2, offset+1,  attr bit1, test 0x10/LIFE
+                0x40,  # part 2, offset+2,  attr bit2 and length bit
+                0x01,  # part 2, offset+3, life1
+                0x02,  # part 2, offset+4, life2
+                0x03,  # part 2, offset+5, life3
+                0x00,  # part 2,
+                0x11,  # part 3, offset+1,  attr bit1, test 0x11/WATER_CONSUMPTION
+                0x40,  # part 3, offset+2,  attr bit2 and length bit
+                0x01,  # part 3, offset+3, water_consumption bit1
+                0x02,  # part 3, offset+4, water_consumption bit2
+                0x03,  # part 3, offset+5, water_consumption bit3
+                0x04,  # part 3, offset+6, water_consumption bit4
+                0x13,  # part 4, offset+1,  attr bit1, test 0x13/TDS
+                0x40,  # part 4, offset+2,  attr bit2 and length bit
+                0x04,  # part 4, offset+3, in_tds bit1
+                0x03,  # part 4, offset+4, in_tds bit2
+                0x02,  # part 4, offset+5, out_tds bit1
+                0x01,  # part 4, offset+6, out_tds bit2
+                0x00,
+            ],
+        )
+        message = MessageEDResponse(header + body)
+        assert hasattr(message, "body_type")
+        assert message.body_type == 255
+        assert hasattr(message, "power")
+        assert message.power
+        assert hasattr(message, "water_consumption")
+        assert message.water_consumption == 67305.985
+        assert hasattr(message, "in_tds")
+        assert message.in_tds == 772
+        assert hasattr(message, "out_tds")
+        assert message.out_tds == 258
+        assert hasattr(message, "child_lock")
+        assert message.child_lock
+        assert hasattr(message, "life1")
+        assert message.life1 == 1
+        assert hasattr(message, "life2")
+        assert message.life2 == 2
+        assert hasattr(message, "life3")
+        assert message.life3 == 3


### PR DESCRIPTION
fix #283 
origin from https://github.com/wuwentao/midea_ac_lan/issues/299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new body type, `X15`, to enhance message categorization.
	- Expanded response handling to accommodate a new message type, improving flexibility in message processing.

- **Improvements**
	- Updated initialization parameters for message handling classes to enhance readability and maintainability.
	- Established a comprehensive suite of unit tests for ED message handling, ensuring robust functionality and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->