### PR TITLE
chore(message): improve debug log for send and received msg with attr…

### DIFF
--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -102,6 +102,14 @@ class MessageType(IntEnum):
     exception2 = (0x0A,)
     query_appliance = 0xA0
 
+    @classmethod
+    def get_key_from_value(cls, value: int) -> str:
+        """Return the key corresponding to the given value."""
+        for key, val in cls.__members__.items():
+            if val == value:
+                return key
+        return "Unknown"
+
 
 ZERO_VALUE = 0x00
 
@@ -169,19 +177,46 @@ class MessageBase:
     def protocol_version(self, protocol_version: int) -> None:
         self._protocol_version = protocol_version
 
+    def _format_attribute(
+        self,
+        value: bytes | bytearray | int | str | bool | object,
+    ) -> int | str | bool | object:
+        """Format value as a hex string if it's bytes or bytearray.
+
+        Args:
+        ----
+            value (bytes | bytearray | int | str | bool): value to be formatted.
+
+        Returns:
+        -------
+            int | str | bool: The formatted result.
+
+        """
+        if isinstance(value, bytes | bytearray):
+            return value.hex()
+        return value
+
     def __str__(self) -> str:
         """Parse to string."""
-        output = {
-            "header": self.header.hex(),
-            "body": self.body.hex(),
-            "message type": f".{f'{self.message_type:02x}'}",
-            "body type": (
-                f".{f'{self._body_type:02x}'}"
-                if self._body_type is not None
-                else "None"
-            ),
+        # get attributes and value
+        attributes = {
+            key: self._format_attribute(value) for key, value in self.__dict__.items()
         }
-        return str(output)
+
+        # update some attributes
+        attributes.update(
+            {
+                "header": self._format_attribute(self.header),
+                "body": self._format_attribute(self.body),
+                "message_type": MessageType.get_key_from_value(self.message_type),
+                "body_type": (
+                    f"{self._body_type:02x}" if self._body_type is not None else "None"
+                ),
+                "self": self,
+            },
+        )
+
+        return str(attributes)
 
 
 class MessageRequest(MessageBase):


### PR DESCRIPTION
1. print all attributes and value to debug log in send and received msg
2. update message_type to the expected type and not the value
3. add self object to debug log
4. add `_format_attribute` func to format all the bytes/bytearray attributes.
5. add  `get_key_from_value` in `MessageType`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve keys from integer values in message types, enhancing user interaction with message classifications.
	- Added a formatting method for message attributes, improving the representation of various data types, including hexadecimal conversion for byte values.

- **Improvements**
	- Enhanced the string representation of message requests for better clarity and usability, making it easier for users to understand message details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->