### PR TITLE
fix(device)!: socket exception and process rebuild

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -20,7 +20,12 @@ from midealocal.cloud import (
     get_midea_cloud,
     get_preset_account_cloud,
 )
-from midealocal.device import AuthException, MideaDevice, ProtocolVersion, RefreshFailed
+from midealocal.device import (
+    AuthException,
+    MideaDevice,
+    NoSupportedProtocol,
+    ProtocolVersion,
+)
 from midealocal.devices import device_selector
 from midealocal.discover import discover
 from midealocal.exceptions import SocketException
@@ -121,7 +126,7 @@ class MideaCLI:
                         _LOGGER.debug("Unable to connect with key: %s", key)
                     except SocketException:
                         _LOGGER.exception("Device socket closed.")
-                    except RefreshFailed:
+                    except NoSupportedProtocol:
                         _LOGGER.exception("Unable to retrieve device attributes.")
                     else:
                         _LOGGER.info("Found device:\n%s", dev.attributes)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -14,7 +14,7 @@ from midealocal.cli import (
     get_config_file_path,
 )
 from midealocal.cloud import MSmartHomeCloud
-from midealocal.device import AuthException, ProtocolVersion, RefreshFailed
+from midealocal.device import AuthException, NoSupportedProtocol, ProtocolVersion
 from midealocal.exceptions import SocketException
 
 
@@ -134,7 +134,7 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             patch.object(
                 mock_device_instance,
                 "refresh_status",
-                side_effect=[None, None, RefreshFailed, None],
+                side_effect=[None, None, NoSupportedProtocol, None],
             ) as refresh_status_mock,
         ):
             mock_discover.return_value = {1: mock_device}
@@ -157,7 +157,7 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             authenticate_mock.reset_mock()
 
             mock_device["protocol"] = ProtocolVersion.V2
-            await self.cli.discover()  # V2 device RefreshFailed
+            await self.cli.discover()  # V2 device NoSupportedProtocol
             authenticate_mock.assert_not_called()
             refresh_status_mock.assert_called_once()
 


### PR DESCRIPTION
changes list:
1. process all the socket send/recv in try/except to prevent socket error
2. always close socket after exception matched and force reconnect to refresh
3. increase query timeout from 1 to 2, and only apply it to query cmd/msg
4. recovery socket timeout after query and recv socket msg done in each for loop.
5. rebuild process to remove the duplicate message parse.
6. rename some func and args
7. with current changes, I don't see any timeout exception in my local device testing, if there is any new error exist, we can continue improve it in future PRs.

Fixes #290 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for device discovery, now reporting `NoSupportedProtocol` for unsupported devices.
	- Streamlined socket connection process, improving reliability and clarity in communication.
	- Introduced `MessageResult` enumeration for improved clarity in message parsing.

- **Bug Fixes**
	- Updated tests to reflect changes in exception handling, ensuring accurate responses to device compatibility issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->