### PR TITLE
fix(device):  prevent while true loop high cpu usage bug

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -637,7 +637,7 @@ class MideaDevice(threading.Thread):
 
     def _recovery_timeout(self) -> None:
         if not self._socket:
-            _LOGGER.warning("[%s] _recovery_timeout socket error", self._device_id)
+            _LOGGER.debug("[%s] _recovery_timeout socket error", self._device_id)
             raise SocketException
         try:
             self._socket.settimeout(SOCKET_TIMEOUT)

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -741,7 +741,7 @@ class MideaDevice(threading.Thread):
                     self.close_socket()
                     break
                 # prevent while True loop cpu 100%
-                time.sleep(1)
+                time.sleep(0.1)
 
     def set_attribute(self, attr: str, value: bool | int | str) -> None:
         """Set attribute."""

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -741,7 +741,7 @@ class MideaDevice(threading.Thread):
                     self.close_socket()
                     break
                 # prevent while True loop cpu 100%
-                time.sleep(5)
+                time.sleep(1)
 
     def set_attribute(self, attr: str, value: bool | int | str) -> None:
         """Set attribute."""

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -740,6 +740,8 @@ class MideaDevice(threading.Thread):
                     )
                     self.close_socket()
                     break
+                # prevent while True loop cpu 100%
+                time.sleep(5)
 
     def set_attribute(self, attr: str, value: bool | int | str) -> None:
         """Set attribute."""


### PR DESCRIPTION
add a sleep in while true loop and prevent high cpu usage bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved performance by adding a delay in the processing loop to reduce CPU resource consumption.
	- Enhanced logging detail for socket error messages to aid in debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->