### PR TITLE
fix: dedup protocol version var

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -94,10 +94,9 @@ class MideaDevice(threading.Thread):
         self._device_name = name
         self._device_id = device_id
         self._device_type = device_type
-        self._protocol = protocol
         self._model = model
         self._subtype = subtype
-        self._protocol_version: ProtocolVersion = ProtocolVersion.V1
+        self._protocol_version = protocol
         self._updates: list[Callable[[dict[str, Any]], None]] = []
         self._unsupported_protocol: list[str] = []
         self._is_run = False
@@ -165,7 +164,7 @@ class MideaDevice(threading.Thread):
             )
             self._socket.connect((self._ip_address, self._port))
             _LOGGER.debug("[%s] Connected", self._device_id)
-            if self._protocol == ProtocolVersion.V3:
+            if self._protocol_version == ProtocolVersion.V3:
                 self.authenticate()
             # 1. midea_ac_lan add device verify token with connect and auth
             # 2. init connection, check_protocol
@@ -231,7 +230,7 @@ class MideaDevice(threading.Thread):
 
     def send_message(self, data: bytes, query: bool = False) -> None:
         """Send message."""
-        if self._protocol == ProtocolVersion.V3:
+        if self._protocol_version == ProtocolVersion.V3:
             self.send_message_v3(data, msg_type=MSGTYPE_ENCRYPTED_REQUEST, query=query)
         else:
             self.send_message_v2(data, query=query)
@@ -400,7 +399,7 @@ class MideaDevice(threading.Thread):
 
     def parse_message(self, msg: bytes) -> MessageResult:
         """Parse message."""
-        if self._protocol == ProtocolVersion.V3:
+        if self._protocol_version == ProtocolVersion.V3:
             messages, self._buffer = self._security.decode_8370(self._buffer + msg)
         else:
             messages, self._buffer = self.fetch_v2_message(self._buffer + msg)


### PR DESCRIPTION
We have 2 variables for the same information:

- `self._protocol = protocol`
- `self._protocol_version: ProtocolVersion = ProtocolVersion.V1`

Those can diverge and checks can fail based on which one is used.
