### PR TITLE
feat(a1): remove inaccurate attributes

### DIFF
--- a/midealocal/devices/a1/message.py
+++ b/midealocal/devices/a1/message.py
@@ -131,10 +131,7 @@ class MessageSet(MessageA1Base):
         self.prompt_tone = False
         self.mode = 1
         self.fan_speed = 40
-        self.child_lock = False
         self.target_humidity = 40
-        self.swing = False
-        self.anion = False
         self.water_level_set = 50
 
     @property
@@ -148,12 +145,6 @@ class MessageSet(MessageA1Base):
         fan_speed = self.fan_speed
         # byte7 target_humidity
         target_humidity = self.target_humidity
-        # byte8 child_lock
-        child_lock = 0x80 if self.child_lock else 0x00
-        # byte9 anion
-        anion = 0x40 if self.anion else 0x00
-        # byte10 swing
-        swing = 0x08 if self.swing else 0x00
         # byte 13 water_level_set
         water_level_set = self.water_level_set
         return bytearray(
@@ -165,9 +156,9 @@ class MessageSet(MessageA1Base):
                 0x00,
                 0x00,
                 target_humidity,
-                child_lock,
-                anion,
-                swing,
+                0x00,
+                0x00,
+                0x00,
                 0x00,
                 0x00,
                 water_level_set,

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -40,20 +40,14 @@ class TestMideaA1Device:
         assert self.device.modes == [
             "Manual",
             "Continuous",
-            "Auto",
-            "Clothes-Dry",
-            "Shoes-Dry",
+            "Max"
         ]
 
     def test_fan_speeds(self) -> None:
         """Test fan speeds."""
         assert self.device.fan_speeds == [
-            "Lowest",
             "Low",
-            "Medium",
-            "High",
-            "Auto",
-            "Off",
+            "High"
         ]
 
     def test_water_level_sets(self) -> None:
@@ -67,7 +61,7 @@ class TestMideaA1Device:
             mock_message.protocol_version = ProtocolVersion.V3
             mock_message.power = True
             mock_message.prompt_tone = False
-            mock_message.fan_speed = 40
+            mock_message.fan_speed = 0
             mock_message.target_humidity = 40
             mock_message.mode = 1
             mock_message.tank = 60
@@ -101,7 +95,7 @@ class TestMideaA1Device:
             mock_message.protocol_version = ProtocolVersion.V3
             mock_message.power = True
             mock_message.prompt_tone = False
-            mock_message.fan_speed = 40
+            mock_message.fan_speed = 0
             mock_message.target_humidity = 40
             mock_message.mode = 1
             mock_message.tank = 60
@@ -112,7 +106,7 @@ class TestMideaA1Device:
         assert isinstance(message_set, MessageSet)
         assert message_set.power
         assert not message_set.prompt_tone
-        assert message_set.fan_speed == 40
+        assert message_set.fan_speed == 0
         assert message_set.mode == 1
 
     def test_set_attribute(self) -> None:
@@ -121,14 +115,11 @@ class TestMideaA1Device:
             self.device.set_attribute(DeviceAttributes.mode, "Continuous")
             mock_build_send.assert_called_once()
 
-            self.device.set_attribute(DeviceAttributes.fan_speed, "Medium")
+            self.device.set_attribute(DeviceAttributes.fan_speed, "High")
             mock_build_send.assert_called()
 
             self.device.set_attribute(DeviceAttributes.water_level_set, "75")
             mock_build_send.assert_called()
 
             self.device.set_attribute(DeviceAttributes.prompt_tone, True)
-            mock_build_send.assert_called()
-
-            self.device.set_attribute(DeviceAttributes.swing, True)
             mock_build_send.assert_called()


### PR DESCRIPTION
## Changes
- Removes `child_lock` as it does not exist on dehumidifiers
- Removes`swing` as it does not exist on dehumidifiers
- Removes `anion` as it does not exist on dehumidifiers

- Adjusts `_modes` to only include the possible dehumidifying odes: “Manual”, “Continuous” & “Max”
- Adjusts `_speeds` to only include the possible dehumidifier fan speeds: “Low” & “High”

---

I've tested all these changes with my personal Midea Cube Dehumidifier, and they work perfectly. The dehumidifier midea-local device now functions properly, and provides the same controls that the Midea app does. There are no longer options that have no effect on the functionality/operation of the dehumidifier.

This will go along with another pull request to the `midea_ac_lan` repository, to remove the references to these attributes that were removed.

To back up my claims that no Midea dehumifiers support these features, here are the owner's manuals for all three dehumidifiers currently being sold by Midea:
- https://www.midea.com/content/dam/midea-aem/us/air-conditioners/dehumidifiers/easydry-22-pint-dehumidifier-mad22c1aws/User%20Manual%20EasyDry%20Dehum%20MADC1YWS.pdf
- https://www.midea.com/content/dam/midea-aem/us/air-conditioners/dehumidifiers/mad20s1qwt/MAD20S1QWT-2024-Cube-Manual.pdf
- https://www.midea.com/content/dam/midea-aem/us/air-conditioners/dehumidifiers/mad50ps1qwt/MAD50PS1QWT-2024-Cube-Manual.pdf