### PR TITLE
fix(ac): refactor to add new binary power format

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -1068,7 +1068,7 @@ class XC1MessageBody(MessageBody):
     @classmethod
     def parse_value(cls, analysis_method: int, databytes: bytearray) -> float:
         """AC C1 message body parse value."""
-        if analysis_method not in PowerFormats:
+        if analysis_method not in PowerFormats._value2member_map_:
             return 0.0  # unknown method
         analysis_function = cls.power_analysis_methods[analysis_method % 10]
         value = 0


### PR DESCRIPTION
merged AC energy / power functions
-> Rewrote these and corresponding calls and helper-functions, to make them more versatile / deduplicate common code

Fixed issue wuwentao/midea_ac_lan#678: AC energy values are x10 of real value (Midea PortaSplit)
-> Introduced format BINARY1 (power_analysis_method 12 = variant of method 2)
Lower digit still represents existing base-formats (BCD, binary, mixed/int), while higher digit(s) can be used to represent different precisions/scalars

Tested changes locally: power_analysis_method 2 and 12 (also got a Midea PortaSplit, actually needing mode 12)

Also, this fixes a bug with energy values >= 655.35 kWh (mode 12) / 6553.5 kWh (existing mode 2), line 1117:
`           return float((byte1 << 32) + (byte2 << 16) + (byte3 << 8) + byte4) / 10`
-> byte1 should be shifted 24 instead of 32 bits

Change needs to be considered in documentation in https://github.com/wuwentao/midea_ac_lan/blob/master/doc/AC.md
Also document it's meaning of interpretation, since it's helpful when migrating from Midea Smart AC (mill1000/midea-ac-py):
- 1 = BCD
- 2 = binary (with default energy/consumption multiplier, so 0.1kWh resolution)
- 3 = mixed/integer
- 12 = binary (with additional x0.1 energy/consumption factor, so 0.01kWh resolution. e.g. Midea PortaSplit)