### PR TITLE
fix(ac): allow half-degree integer temperatures

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -809,13 +809,16 @@ class XMessageBody(MessageBody):
     """AC A1/C0 message body - common functions."""
 
     @staticmethod
-    def parse_temperature(integer: int, decimal: int) -> float:
+    def parse_temperature(integer: int, decimal: int) -> float | None:
+        """Decode special signed integer with BCD decimal temperature format."""
         if integer == MAX_BYTE_VALUE:
             return None
-        temp_integer = int((integer - 50) / 2)
+        temp_integer = (integer - 50) / 2
+        if decimal == 0:
+            return temp_integer
         if temp_integer < 0:
-            return temp_integer - decimal * 0.1
-        return temp_integer + decimal * 0.1
+            return int(temp_integer) - decimal * 0.1
+        return int(temp_integer) + decimal * 0.1
 
 
 class XA1MessageBody(XMessageBody):


### PR DESCRIPTION
This is deduplicating the temperature functions, and then finally dropping the int(...) cast on the "integer" temperature value. This is used on e.g. the Midea PortaSplit, which reports half-degree values via this field (decimal value = 0).

I'd think if a device reports a decimal value as int + decimal, then it won't report half-degree steps for the integer, and the casting of the integer would be redundant. To be on the safe side though, and avoid potential regressions, I've implemented it to only return the integer as float, if the decimal really is 0. So even if the integer is reported with half-degree steps *and* a seperate decimal simultaneously, it'd be fine, since in that case the integer should be a whole number anyway.

PS: Let me know if and what you'd want as "proof", e.g. HA or Midea-App screenshots, debug logs (before or after fix), etc., and I'll provide it (just don't want to waste time on unnecessary stuff)