### PR TITLE
fix(main): fix default apt/pip mirror; removed deprecated pylint option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "APT_MIRROR_DOMAIN": "${localEnv:APT_MIRROR_DOMAIN:-deb.debian.org}",
-      "PIP_MIRROR_DOMAIN": "${localEnv:PIP_MIRROR_DOMAIN:-pypi.org}"
+      "APT_MIRROR_DOMAIN": "${localEnv:APT_MIRROR_DOMAIN:deb.debian.org}",
+      "PIP_MIRROR_DOMAIN": "${localEnv:PIP_MIRROR_DOMAIN:pypi.org}"
     }
   },
   "postCreateCommand": "scripts/setup.sh",

--- a/pylintrc
+++ b/pylintrc
@@ -22,7 +22,8 @@ recursive=true
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# deprecated in pylint v4.0.0
+# suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.


### PR DESCRIPTION
Proposal, as highlighted in https://github.com/midea-lan/midea-local/pull/411#issuecomment-3485599025

### VSCode/devcontainer setup and proxy config

> @folfy sorry, as most of us under GFW in china network, we can't directly access github/pip/docker/etc, so we need to config a local mirror about these sites: ` export APT_MIRROR_DOMAIN=xxxxx`, or redirect these domain to proxy.
> 
> for windows user, **WSL2** should be the expected solution with VScode + devcontainer. install a ubuntu under windows WS2, all these feature should works. finally, I will try to add some info in CONTRIBUTING.md.

Yeah, I already had WSL2 with Ubuntu installed, but still ran into all these issues mentioned above. At least the devcontainer.json should be fixed:
`"PIP_MIRROR_DOMAIN": "${localEnv:PIP_MIRROR_DOMAIN:-pypi.org}"`
I found out that "localEnv:PIP_MIRROR_DOMAIN" is a docker (compose?) directive to get this from the users environment. Not sure where / how the default value is expanded, but removing the dash after the colon fixes the issue (using the last value as default), so proposing that fix.

### Pylint config issue

Unfortunately tests don't seem to run here - I think cause I got some other Pylint error here still, that I didn't bother to investigate before:
```
Unrecognized option found: suggestion-mode Pylint(E0015:unrecognized-option)
```
Seems your setting pylintrc:25 `suggestion-mode=yes` has been deprecated in Pylint 4.0:
https://pylint.readthedocs.io/en/latest/whatsnew/4/4.0/index.html
So I removed that option.