### PR TITLE
build: make environment work for both EU and China developers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,21 +11,22 @@ ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# .bashrc or .zshrc add mirror site:
-# export APT_MIRROR_DOMAIN="mirrors.tuna.tsinghua.edu.cn"
-# --- BEGIN: APT China Mirror Configuration ---
-RUN cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
+# [Optional] Override APT mirror for China users:
+# Set in your local shell profile: export APT_MIRROR_DOMAIN="mirrors.tuna.tsinghua.edu.cn"
+RUN if [ "${APT_MIRROR_DOMAIN}" != "deb.debian.org" ]; then \
+    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
     sed -i "s|deb.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list && \
     sed -i "s|security.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list && \
-    apt-get clean all && rm -rf /var/lib/apt/lists/* && apt-get update
+    apt-get clean all && rm -rf /var/lib/apt/lists/* && apt-get update; \
+    fi
 
-# .bashrc or .zshrc add mirror site:
-# export PIP_MIRROR_DOMAIN="pypi.tuna.tsinghua.edu.cn"
-# --- BEGIN: PIP China Mirror Configuration ---
-RUN echo "[global]" > /etc/pip.conf && \
+# [Optional] Override pip mirror for China users:
+# Set in your local shell profile: export PIP_MIRROR_DOMAIN="pypi.tuna.tsinghua.edu.cn"
+RUN if [ "${PIP_MIRROR_DOMAIN}" != "pypi.org" ]; then \
+    echo "[global]" > /etc/pip.conf && \
     echo "index-url = https://${PIP_MIRROR_DOMAIN}/simple" >> /etc/pip.conf && \
-    echo "trusted-host = ${PIP_MIRROR_DOMAIN}" >> /etc/pip.conf
-# --- END: PIP Mirror Configuration ---
+    echo "trusted-host = ${PIP_MIRROR_DOMAIN}" >> /etc/pip.conf; \
+    fi
 
 # Install Python dependencies from requirements
 COPY requirements*.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/scripts/sync_pyutils.sh
+++ b/scripts/sync_pyutils.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Sync /usr/local/py-utils tool venvs with the system pip versions.
+# Upgrades any tool whose venv version is older than what pip has installed.
+
+set -euo pipefail
+
+VENVS_DIR="/usr/local/py-utils/venvs"
+UPDATED=0
+SKIPPED=0
+NOT_FOUND=0
+
+pkg_version_in_venv() {
+    local venv="$1"
+    local pkg="$2"
+    # Expand the python version glob using ls -d
+    local site_packages
+    site_packages=$(ls -d "${venv}/lib/python"*/site-packages 2>/dev/null | head -1)
+    if [[ -z "${site_packages}" ]]; then
+        return 1
+    fi
+    # Find the dist-info directory for this package (case-insensitive, handles dashes/underscores)
+    local dist_info
+    dist_info=$(find "${site_packages}" -maxdepth 1 -type d \
+        -iname "${pkg}-*.dist-info" 2>/dev/null | head -1)
+    if [[ -z "${dist_info}" ]]; then
+        return 1
+    fi
+    # Extract version from directory name: <pkg>-<version>.dist-info
+    basename "${dist_info}" | sed 's/\.dist-info$//' | rev | cut -d- -f1 | rev
+}
+
+pkg_version_in_sys() {
+    local pkg="$1"
+    pip show "${pkg}" 2>/dev/null | awk '/^Version:/{print $2}'
+}
+
+# Compare two version strings; returns 0 if $1 < $2
+version_lt() {
+    python3 -c "
+import sys
+from packaging.version import Version
+sys.exit(0 if Version('$1') < Version('$2') else 1)
+" 2>/dev/null
+}
+
+for venv_dir in "${VENVS_DIR}"/*/; do
+    tool=$(basename "${venv_dir}")
+
+    venv_ver=$(pkg_version_in_venv "${venv_dir}" "${tool}" 2>/dev/null || true)
+    if [[ -z "${venv_ver}" ]]; then
+        echo "[SKIP] ${tool}: not found in venv"
+        (( NOT_FOUND++ )) || true
+        continue
+    fi
+
+    sys_ver=$(pkg_version_in_sys "${tool}" || true)
+    if [[ -z "${sys_ver}" ]]; then
+        echo "[SKIP] ${tool}: not found in system pip"
+        (( SKIPPED++ )) || true
+        continue
+    fi
+
+    if version_lt "${venv_ver}" "${sys_ver}"; then
+        echo "[UPDATE] ${tool}: ${venv_ver} -> ${sys_ver}"
+        "${venv_dir}bin/python" -m pip install --quiet --upgrade "${tool}==${sys_ver}"
+        (( UPDATED++ )) || true
+    else
+        echo "[OK]     ${tool}: ${venv_ver}"
+        (( SKIPPED++ )) || true
+    fi
+done
+
+echo ""
+echo "Done. Updated: ${UPDATED}, Already up-to-date: ${SKIPPED}, Not found: ${NOT_FOUND}"


### PR DESCRIPTION
The Dockerfile now applies package mirrors only when custom mirror domains are set.

- Developers outside China: no changes needed. If you don’t set any mirror variables, the build behaves exactly as before.

- Developers in China: add the following to your local ~/.bashrc or ~/.zshrc to use faster regional mirrors:

```bash
export APT_MIRROR_DOMAIN="mirrors.tuna.tsinghua.edu.cn"
export PIP_MIRROR_DOMAIN="pypi.tuna.tsinghua.edu.cn"
```
  Then rebuild the dev container.
