### PR TITLE
feat(ac): add out_silent (outdoor silent mode) support for PortaSplit

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -72,6 +72,7 @@ class DeviceAttributes(StrEnum):
     current_operating_time = "current_operating_time"
     wind_lr_angle = "wind_lr_angle"
     wind_ud_angle = "wind_ud_angle"
+    out_silent = "out_silent"
 
 
 class MideaACDevice(MideaDevice):
@@ -169,6 +170,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.fresh_air_2: None,
                 DeviceAttributes.wind_lr_angle: None,
                 DeviceAttributes.wind_ud_angle: None,
+                DeviceAttributes.out_silent: False,
             },
         )
         self._fresh_air_version: DeviceAttributes | None = None
@@ -439,6 +441,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.fresh_air_mode,
                 DeviceAttributes.wind_lr_angle,
                 DeviceAttributes.wind_ud_angle,
+                DeviceAttributes.out_silent,
             ]:
                 message = self.make_newprotocol_message_set(attr=attr, value=value)
             elif attr in self._attributes:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -30,6 +30,7 @@ FRESH_AIR_LENGTH = 2
 FROST_PROTECT_MIN_LENGTH = 22
 INDIRECT_WIND_VALUE = 0x02
 MAX_MSG_SERIAL_NUM = 254
+OUT_SILENT_VALUE = 0x03
 SCREEN_DISPLAY_BYTE_CHECK = 0x07
 SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
@@ -130,6 +131,8 @@ class NewProtocolTags(IntEnum):
     b5_screen_display = 0x0224
     b5_anion = 0x021E
     b5_sound = 0x022C
+    # AC outdoor silent mode (PortaSplit)
+    out_silent = 0x00CD
 
 
 class MessageACBase(MessageRequest):
@@ -391,6 +394,7 @@ class MessageNewProtocolQuery(MessageACBase):
             NewProtocolTags.fresh_air_2,
             NewProtocolTags.wind_lr_angle,
             NewProtocolTags.wind_ud_angle,
+            NewProtocolTags.out_silent,
         ]
 
         _body = bytearray([len(query_params)])
@@ -654,6 +658,7 @@ class MessageNewProtocolSet(MessageACBase):
         self.fresh_air_2: bytes | None = None
         self.wind_lr_angle: bytes | None = None
         self.wind_ud_angle: bytes | None = None
+        self.out_silent: bool | None = None
 
     @property
     def _body(self) -> bytearray:
@@ -740,6 +745,16 @@ class MessageNewProtocolSet(MessageACBase):
                 NewProtocolMessageBody.pack(
                     param=NewProtocolTags.wind_ud_angle,
                     value=bytearray([wind_ud_angle if wind_ud_angle else 0x00]),
+                ),
+            )
+        if self.out_silent is not None:
+            pack_count += 1
+            payload.extend(
+                NewProtocolMessageBody.pack(
+                    param=NewProtocolTags.out_silent,
+                    # Device requires 0x03 to activate, 0x00 to deactivate
+                    # Sending 0x01 results in an error from the firmware
+                    value=bytearray([OUT_SILENT_VALUE if self.out_silent else 0x00]),
                 ),
             )
         payload[0] = pack_count
@@ -876,6 +891,8 @@ class XBXMessageBody(NewProtocolMessageBody):
             self.wind_lr_angle = params[NewProtocolTags.wind_lr_angle][0]
         if NewProtocolTags.wind_ud_angle in params:
             self.wind_ud_angle = params[NewProtocolTags.wind_ud_angle][0]
+        if NewProtocolTags.out_silent in params:
+            self.out_silent = params[NewProtocolTags.out_silent][0] == OUT_SILENT_VALUE
 
 
 class XB5MessageBody(NewProtocolMessageBody):

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -48,6 +48,7 @@ class TestMideaACDevice:
         assert self.device.attributes[DeviceAttributes.fan_speed] == 102
         assert not self.device.attributes[DeviceAttributes.swing_vertical]
         assert not self.device.attributes[DeviceAttributes.swing_horizontal]
+        assert not self.device.attributes[DeviceAttributes.out_silent]
         assert self.device.temperature_step == 1
         assert self.device.fresh_air_fan_speeds is not None
 
@@ -116,6 +117,12 @@ class TestMideaACDevice:
             self.device.set_attribute(DeviceAttributes.fresh_air_mode.value, False)
             mock_build_send.assert_called()
 
+            self.device.set_attribute(DeviceAttributes.out_silent.value, True)
+            mock_build_send.assert_called()
+
+            self.device.set_attribute(DeviceAttributes.out_silent.value, False)
+            mock_build_send.assert_called()
+
     def test_build_query(self) -> None:
         """Test build query."""
         self.device._used_subprotocol = True
@@ -172,6 +179,7 @@ class TestMideaACDevice:
             mock_message.fresh_air_fan_speed = 0
             mock_message.fresh_air_1 = 1
             mock_message.fresh_air_2 = 1
+            mock_message.out_silent = True
 
             result = self.device.process_message(b"")
             assert result[DeviceAttributes.power.value]
@@ -205,6 +213,7 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.fresh_air_mode.value] == "off"
             assert result[DeviceAttributes.fresh_air_1.value] == 1
             assert result[DeviceAttributes.fresh_air_2.value] == 1
+            assert result[DeviceAttributes.out_silent.value]
 
             mock_message.fresh_air_fan_speed = 55
             mock_message.fresh_air_1 = None

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -9,6 +9,7 @@ from midealocal.devices.ac.message import (
     MessageCapabilitiesQuery,
     MessageGeneralSet,
     MessageNewProtocolQuery,
+    MessageNewProtocolSet,
     MessagePowerQuery,
     MessageQuery,
     MessageSubProtocol,
@@ -186,7 +187,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x08,
+                0x09,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -203,9 +204,39 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.wind_lr_angle >> 8,
                 NewProtocolTags.wind_ud_angle & 0xFF,
                 NewProtocolTags.wind_ud_angle >> 8,
+                NewProtocolTags.out_silent & 0xFF,
+                NewProtocolTags.out_silent >> 8,
             ],
         )
         assert msg.body[:-2] == expected_body
+
+
+class TestMessageNewProtocolSetOutSilent:
+    """Test Message New Protocol Set for out_silent."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_byte"),
+        [(True, 0x03), (False, 0x00)],
+    )
+    def test_out_silent_on_off(self, value: bool, expected_byte: int) -> None:
+        """Test out_silent set to on/off sends correct byte."""
+        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg.out_silent = value
+        body = msg.body
+        assert body[0] == 0xB0
+        assert body[1] == 0x01  # 1 param packed
+        assert body[2] == NewProtocolTags.out_silent & 0xFF  # 0xCD
+        assert body[3] == NewProtocolTags.out_silent >> 8  # 0x00
+        assert body[4] == 0x01  # length byte
+        assert body[5] == expected_byte
+
+    def test_out_silent_none_not_packed(self) -> None:
+        """Test out_silent None does not add to payload."""
+        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        # out_silent defaults to None, should not be packed
+        body = msg.body
+        assert body[0] == 0xB0
+        assert body[1] == 0x00  # 0 params packed
 
 
 class TestMessageSubProtocol:
@@ -554,6 +585,29 @@ class TestMessageACResponse:
         assert hasattr(response, "fresh_air_power")
         assert hasattr(response, "fresh_air_fan_speed")
         assert response.fresh_air_fan_speed == 20
+
+    @pytest.mark.parametrize(
+        ("raw_value", "expected"),
+        [(0x03, True), (0x00, False)],
+    )
+    def test_message_notify2_b0_out_silent(
+        self,
+        raw_value: int,
+        expected: bool,
+    ) -> None:
+        """Test Message parse notify2 B0 with out_silent."""
+        body = bytearray(10)
+        body[0] = 0xB0  # Body type
+        body[1] = 0x01  # Params count
+        body[2] = NewProtocolTags.out_silent & 0xFF  # Low byte 0xCD
+        body[3] = NewProtocolTags.out_silent >> 8  # High byte 0x00
+        body[4] = 0x00  # Padding
+        body[5] = 0x01  # Value length
+        body[6] = raw_value
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "out_silent")
+        assert response.out_silent is expected
 
     def test_message_query_c0(self) -> None:
         """Test Message parse query C0."""


### PR DESCRIPTION
## Description

Add support for the **Out Silent Mode** feature (capability `0x00CD`) used by the Midea PortaSplit device. This feature reduces outdoor unit noise by ~6dB.

### Protocol details
- Activating requires sending byte `0x03`
- Deactivating requires sending byte `0x00`
- Sending standard boolean `0x01` results in a `0x11` (invalid value) error from the firmware

### Changes
- Add `out_silent = 0x00CD` to `NewProtocolTags` enum
- Add `out_silent` to `DeviceAttributes`
- Add query support in `MessageNewProtocolQuery`
- Add set support in `MessageNewProtocolSet` with correct `0x03`/`0x00` encoding
- Add response parsing in `XBXMessageBody`
- Route through `make_newprotocol_message_set` in `set_attribute`

### Context
- Feature request: wuwentao/midea_ac_lan#779
- Protocol analysis from: mill1000/midea-msmart#258 (merged)
- Tested locally on a PortaSplit device with the Jan 2026 firmware

### Related
A companion PR for the Home Assistant integration side (switch entity) will follow in `wuwentao/midea_ac_lan` once this is merged.