### PR TITLE
feat(ac): add anion, sound, self_clean, pmv and error_code support

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -73,6 +73,11 @@ class DeviceAttributes(StrEnum):
     wind_lr_angle = "wind_lr_angle"
     wind_ud_angle = "wind_ud_angle"
     out_silent = "out_silent"
+    anion = "anion"
+    sound = "sound"
+    self_clean = "self_clean"
+    pmv = "pmv"
+    error_code = "error_code"
 
 
 class MideaACDevice(MideaDevice):
@@ -171,6 +176,11 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.wind_lr_angle: None,
                 DeviceAttributes.wind_ud_angle: None,
                 DeviceAttributes.out_silent: False,
+                DeviceAttributes.anion: False,
+                DeviceAttributes.sound: True,
+                DeviceAttributes.self_clean: False,
+                DeviceAttributes.pmv: None,
+                DeviceAttributes.error_code: 0,
             },
         )
         self._fresh_air_version: DeviceAttributes | None = None
@@ -306,6 +316,7 @@ class MideaACDevice(MideaDevice):
         message.temp_fahrenheit = self._attributes[DeviceAttributes.temp_fahrenheit]
         message.frost_protect = self._attributes[DeviceAttributes.frost_protect]
         message.comfort_mode = self._attributes[DeviceAttributes.comfort_mode]
+        message.anion = self._attributes[DeviceAttributes.anion]
         return message
 
     def make_newprotocol_message_set(
@@ -442,6 +453,8 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.wind_lr_angle,
                 DeviceAttributes.wind_ud_angle,
                 DeviceAttributes.out_silent,
+                DeviceAttributes.sound,
+                DeviceAttributes.self_clean,
             ]:
                 message = self.make_newprotocol_message_set(attr=attr, value=value)
             elif attr in self._attributes:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -395,6 +395,8 @@ class MessageNewProtocolQuery(MessageACBase):
             NewProtocolTags.wind_lr_angle,
             NewProtocolTags.wind_ud_angle,
             NewProtocolTags.out_silent,
+            NewProtocolTags.buzzer_all,
+            NewProtocolQuery.error_code_query,
         ]
 
         _body = bytearray([len(query_params)])
@@ -575,6 +577,7 @@ class MessageGeneralSet(MessageACBase):
         self.natural_wind = False
         self.frost_protect = False
         self.comfort_mode = False
+        self.anion = False
 
     @property
     def _body(self) -> bytearray:
@@ -601,6 +604,7 @@ class MessageGeneralSet(MessageACBase):
         dry = 0x04 if self.dry else 0
         aux_heating = 0x08 if self.aux_heating else 0
         eco_mode = 0x80 if self.eco_mode else 0
+        anion = 0x20 if self.anion else 0
         # Byte 10 temp_fahrenheit
         temp_fahrenheit = 0x04 if self.temp_fahrenheit else 0
         sleep_mode = 0x01 if self.sleep_mode else 0
@@ -622,7 +626,7 @@ class MessageGeneralSet(MessageACBase):
                 0x00,
                 swing_mode,
                 boost_mode,
-                smart_eye | dry | aux_heating | eco_mode,
+                smart_eye | dry | aux_heating | eco_mode | anion,
                 temp_fahrenheit | sleep_mode | boost_mode_1,
                 0x00,
                 0x00,
@@ -659,6 +663,8 @@ class MessageNewProtocolSet(MessageACBase):
         self.wind_lr_angle: bytes | None = None
         self.wind_ud_angle: bytes | None = None
         self.out_silent: bool | None = None
+        self.sound: bool | None = None
+        self.self_clean: bool | None = None
 
     @property
     def _body(self) -> bytearray:
@@ -757,6 +763,22 @@ class MessageNewProtocolSet(MessageACBase):
                     value=bytearray([OUT_SILENT_VALUE if self.out_silent else 0x00]),
                 ),
             )
+        if self.sound is not None:
+            pack_count += 1
+            payload.extend(
+                NewProtocolMessageBody.pack(
+                    param=NewProtocolTags.buzzer_all,
+                    value=bytearray([0x01 if self.sound else 0x00]),
+                ),
+            )
+        if self.self_clean is not None:
+            pack_count += 1
+            payload.extend(
+                NewProtocolMessageBody.pack(
+                    param=NewProtocolTags.self_clean,
+                    value=bytearray([0x01 if self.self_clean else 0x00]),
+                ),
+            )
         payload[0] = pack_count
         return payload
 
@@ -790,6 +812,7 @@ class XA0MessageBody(MessageBody):
         self.dry = (body[9] & 0x04) > 0  # dryValue
         self.aux_heating = (body[9] & 0x08) > 0  # PTCValue
         self.purifier = body[9] & 0x20  # purifierValue
+        self.anion = (body[9] & 0x20) > 0
         self.eco_mode = (body[9] & 0x10) > 0  # ecoValue
         self.sleep_mode = (body[10] & 0x01) > 0
         self.natural_wind = (body[10] & 0x40) > 0  # naturalWind
@@ -893,6 +916,10 @@ class XBXMessageBody(NewProtocolMessageBody):
             self.wind_ud_angle = params[NewProtocolTags.wind_ud_angle][0]
         if NewProtocolTags.out_silent in params:
             self.out_silent = params[NewProtocolTags.out_silent][0] == OUT_SILENT_VALUE
+        if NewProtocolTags.buzzer_all in params:
+            self.sound = params[NewProtocolTags.buzzer_all][0] > 0
+        if NewProtocolQuery.error_code_query in params:
+            self.error_code = params[NewProtocolQuery.error_code_query][0]
 
 
 class XB5MessageBody(NewProtocolMessageBody):
@@ -956,6 +983,7 @@ class XC0MessageBody(XMessageBody):
         self.eco_mode = (body[9] & 0x10) > 0  # ecoValue
         self.aux_heating = (body[9] & 0x08) > 0  # PTCValue
         self.purifier = body[9] & 0x20  # purifierValue
+        self.anion = (body[9] & 0x20) > 0
         self.temp_fahrenheit = (body[10] & 0x04) > 0
         self.sleep_mode = (body[10] & 0x01) > 0
         decimal = body[15] if len(body) > TEMP_DECIMAL_MIN_BODY_LENGTH else 0

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -15,6 +15,7 @@ from midealocal.devices.ac.message import (
     MessageSubProtocol,
     MessageSubProtocolSet,
     MessageToggleDisplay,
+    NewProtocolQuery,
     NewProtocolTags,
 )
 from midealocal.message import ListTypes, MessageType
@@ -187,7 +188,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x09,
+                0x0B,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -206,6 +207,10 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.wind_ud_angle >> 8,
                 NewProtocolTags.out_silent & 0xFF,
                 NewProtocolTags.out_silent >> 8,
+                NewProtocolTags.buzzer_all & 0xFF,
+                NewProtocolTags.buzzer_all >> 8,
+                NewProtocolQuery.error_code_query & 0xFF,
+                NewProtocolQuery.error_code_query >> 8,
             ],
         )
         assert msg.body[:-2] == expected_body
@@ -885,3 +890,118 @@ class TestMessageACResponse:
         body[5] = 0x13
         response = MessageACResponse(self.header + body)
         assert not hasattr(response, "power")
+
+    def test_message_query_c0_anion(self) -> None:
+        """Test anion parsed from C0 body (purifier bit 0x20 in byte 9)."""
+        self.header[9] = 0x03
+        body = bytearray(24)
+        body[0] = 0xC0
+        body[9] = 0x20  # purifier/anion bit set
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "anion")
+        assert response.anion is True
+
+        body[9] = 0x00
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "anion")
+        assert response.anion is False
+
+    def test_message_query_c0_pmv(self) -> None:
+        """Test PMV parsed from C0 body (low nibble of byte 14)."""
+        self.header[9] = 0x03
+        body = bytearray(24)
+        body[0] = 0xC0
+        body[14] = 0x07  # PMV nibble = 7 → 7*0.5 - 3.5 = 0.0
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "pmv")
+        assert response.pmv == 0.0
+
+        body[14] = 0x00  # PMV nibble = 0 → 0*0.5 - 3.5 = -3.5
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "pmv")
+        assert response.pmv == -3.5
+
+    def test_message_b1_error_code(self) -> None:
+        """Test error_code parsed from B1 response."""
+        self.header[9] = 0x03
+        body = bytearray(10)
+        body[0] = 0xB1
+        body[1] = 0x01  # 1 param
+        body[2] = NewProtocolQuery.error_code_query & 0xFF
+        body[3] = NewProtocolQuery.error_code_query >> 8
+        body[4] = 0x00  # padding
+        body[5] = 0x01  # length
+        body[6] = 0x05  # error code 5
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "error_code")
+        assert response.error_code == 5
+
+    def test_message_b1_sound(self) -> None:
+        """Test sound parsed from B1 response (buzzer_all tag)."""
+        self.header[9] = 0x03
+        body = bytearray(10)
+        body[0] = 0xB1
+        body[1] = 0x01
+        body[2] = NewProtocolTags.buzzer_all & 0xFF
+        body[3] = NewProtocolTags.buzzer_all >> 8
+        body[4] = 0x00
+        body[5] = 0x01
+        body[6] = 0x01  # sound on
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "sound")
+        assert response.sound is True
+
+        body[6] = 0x00
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "sound")
+        assert response.sound is False
+
+
+class TestMessageNewProtocolSetNewFeatures:
+    """Test MessageNewProtocolSet for sound and self_clean."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_byte"),
+        [(True, 0x01), (False, 0x00)],
+    )
+    def test_sound_on_off(self, value: bool, expected_byte: int) -> None:
+        """Test sound set to on/off sends correct byte."""
+        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg.sound = value
+        body = msg.body
+        assert body[0] == 0xB0
+        assert body[1] == 0x01
+        assert body[2] == NewProtocolTags.buzzer_all & 0xFF
+        assert body[3] == NewProtocolTags.buzzer_all >> 8
+        assert body[4] == 0x01
+        assert body[5] == expected_byte
+
+    @pytest.mark.parametrize(
+        ("value", "expected_byte"),
+        [(True, 0x01), (False, 0x00)],
+    )
+    def test_self_clean_on_off(self, value: bool, expected_byte: int) -> None:
+        """Test self_clean set to on/off sends correct byte."""
+        msg = MessageNewProtocolSet(protocol_version=ProtocolVersion.V1)
+        msg.self_clean = value
+        body = msg.body
+        assert body[0] == 0xB0
+        assert body[1] == 0x01
+        assert body[2] == NewProtocolTags.self_clean & 0xFF
+        assert body[3] == NewProtocolTags.self_clean >> 8
+        assert body[4] == 0x01
+        assert body[5] == expected_byte
+
+
+class TestMessageGeneralSetAnion:
+    """Test MessageGeneralSet anion (purifier) bit."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_bit"),
+        [(True, 0x20), (False, 0x00)],
+    )
+    def test_anion_bit_in_body(self, value: bool, expected_bit: int) -> None:
+        """Test anion sets bit 0x20 in body byte index 8."""
+        msg = MessageGeneralSet(protocol_version=ProtocolVersion.V1)
+        msg.anion = value
+        assert msg._body[8] & 0x20 == expected_bit


### PR DESCRIPTION
# Description
Add support for anion (ionizer), sound (beeping on setting change), self_clean, PMV sensor and error code attributes for Midea AC devices.

  ---
  ### Protocol details
  
  Anion (ionizer)
  - State is read from the C0/A0 response body byte 9, bit 0x20 (the purifierValue flag already parsed but not exposed)
  - Controlled via MessageGeneralSet body byte 8, bit 0x20 — same byte as dry/aux_heating/eco_mode
  - Setting via new-protocol B0 tag 0x021E is silently ignored by the firmware; the general set path is required

  Sound
  - Uses pre-existing tag 0x022C (buzzer_all) already defined in NewProtocolTags but never queried, parsed or exposed.  Wired up query, response parsing and set support

  Self-clean
  - Triggers the self-cleaning cycle (fan dries evaporator, then unit shuts down)
  - Set-only via new-protocol tag 0x0039 (self_clean), value 0x01 to trigger / 0x00 to cancel
  - No "in progress" status bit is returned by the device; attribute stays False after polling

  PMV (Predicted Mean Vote)
  - Thermal comfort index per ASHRAE standard, range −3.5 (cold) to +3.5 (hot), 0 = neutral
  - Already parsed in XC0MessageBody and XA0MessageBody but never exposed
  - Read from C0 body byte 14 low nibble: (byte & 0x0F) * 0.5 - 3.5

  Error code
  - Device fault code; 0 = no fault, non-zero = firmware error code
  - Queried via new-protocol tag 0x003F (error_code_query) added to MessageNewProtocolQuery
  - Parsed from B1 response in XBXMessageBody

  ###  Changes

  - Add anion, sound, self_clean, pmv, error_code to DeviceAttributes
  - Add anion field to MessageGeneralSet with bit 0x20 in body byte 8
  - Add anion attribute to XC0MessageBody and XA0MessageBody (alongside existing purifier)
  - Add sound and error_code parsing to XBXMessageBody
  - Add sound, self_clean fields to MessageNewProtocolSet with pack support
  - Add buzzer_all and error_code_query to MessageNewProtocolQuery tag list
  - Route sound and self_clean through make_newprotocol_message_set in set_attribute
  - Route anion through make_message_set / general set path in set_attribute

 ### Context
  
  Capability presence confirmed via B5 capability query on a live device:
  - b5_anion (0x021E) = 1 → ionizer supported
  - b5_sound (0x022C) = 1 → persistent buzzer control supported
  - self_clean (0x0039) = 1 → self-clean supported

  Tested locally on a PortaSplit with Jan 2026 firmware — all five attributes read and write correctly confirmed via live device interaction.