### PR TITLE
feat(a1): add dehumidifier pump state and control

### DIFF
--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -96,6 +96,7 @@ class MideaA1Device(MideaDevice):
                 DeviceAttributes.filter_cleaning_reminder: False,
             },
         )
+        self._pump_enable = False
         self._speeds = self._default_speeds
         self._modes = self._default_modes
         self.set_customize(customize)
@@ -123,6 +124,9 @@ class MideaA1Device(MideaDevice):
         """Midea A1 device process message."""
         message = MessageA1Response(bytearray(msg))
         self._message_protocol_version = message.protocol_version
+        # Preserve the hidden pump capability bit for future set packets.
+        if hasattr(message, "pump_enable"):
+            self._pump_enable = message.pump_enable
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         for status in self._attributes:
@@ -186,6 +190,8 @@ class MideaA1Device(MideaDevice):
         message.target_humidity = self._attributes[DeviceAttributes.target_humidity]
         message.swing = self._attributes[DeviceAttributes.swing]
         message.anion = self._attributes[DeviceAttributes.anion]
+        message.pump = self._attributes[DeviceAttributes.pump]
+        message.pump_enable = self._pump_enable
         message.water_level_set = int(
             self._attributes[DeviceAttributes.water_level_set],
         )

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -24,6 +24,7 @@ class DeviceAttributes(StrEnum):
     swing = "swing"
     target_humidity = "target_humidity"
     anion = "anion"
+    pump = "pump"
     tank = "tank"
     water_level_set = "water_level_set"
     tank_full = "tank_full"
@@ -86,6 +87,7 @@ class MideaA1Device(MideaDevice):
                 DeviceAttributes.swing: False,
                 DeviceAttributes.target_humidity: 35,
                 DeviceAttributes.anion: False,
+                DeviceAttributes.pump: False,
                 DeviceAttributes.tank: 0,
                 DeviceAttributes.water_level_set: 50,
                 DeviceAttributes.tank_full: None,

--- a/midealocal/devices/a1/message.py
+++ b/midealocal/devices/a1/message.py
@@ -135,6 +135,8 @@ class MessageSet(MessageA1Base):
         self.target_humidity = 40
         self.swing = False
         self.anion = False
+        self.pump = False
+        self.pump_enable = False
         self.water_level_set = 50
 
     @property
@@ -150,8 +152,10 @@ class MessageSet(MessageA1Base):
         target_humidity = self.target_humidity
         # byte8 child_lock
         child_lock = 0x80 if self.child_lock else 0x00
-        # byte9 anion
+        # byte9 anion, pump, pump enable
         anion = 0x40 if self.anion else 0x00
+        pump = 0x08 if self.pump else 0x00
+        pump_enable = 0x10 if self.pump_enable else 0x00
         # byte10 swing
         swing = 0x08 if self.swing else 0x00
         # byte 13 water_level_set
@@ -166,7 +170,7 @@ class MessageSet(MessageA1Base):
                 0x00,
                 target_humidity,
                 child_lock,
-                anion,
+                anion | pump | pump_enable,
                 swing,
                 0x00,
                 0x00,
@@ -223,6 +227,7 @@ class A1GeneralMessageBody(MessageBody):
         self.child_lock = (body[8] & 0x80) > 0
         self.anion = (body[9] & 0x40) > 0
         self.pump = (body[9] & 0x08) > 0
+        self.pump_enable = (body[9] & 0x10) > 0
         self.tank = body[10] & 0x7F
         self.water_level_set = body[15]
         self.current_humidity = body[16]

--- a/midealocal/devices/a1/message.py
+++ b/midealocal/devices/a1/message.py
@@ -222,6 +222,7 @@ class A1GeneralMessageBody(MessageBody):
         self.target_humidity = max(body[7], MIN_TARGET_HUMIDITY)
         self.child_lock = (body[8] & 0x80) > 0
         self.anion = (body[9] & 0x40) > 0
+        self.pump = (body[9] & 0x08) > 0
         self.tank = body[10] & 0x7F
         self.water_level_set = body[15]
         self.current_humidity = body[16]

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -74,6 +74,7 @@ class TestMideaA1Device:
             mock_message.pump = True
             mock_message.tank = 60
             mock_message.water_level_set = "50"
+            mock_message.pump_enable = True
             new_status = self.device.process_message(b"")
             assert new_status[DeviceAttributes.power.value]
             assert not new_status[DeviceAttributes.prompt_tone.value]
@@ -107,6 +108,8 @@ class TestMideaA1Device:
             mock_message.fan_speed = 40
             mock_message.target_humidity = 40
             mock_message.mode = 1
+            mock_message.pump = True
+            mock_message.pump_enable = True
             mock_message.tank = 60
             mock_message.water_level_set = "50"
             self.device.process_message(b"")
@@ -117,6 +120,8 @@ class TestMideaA1Device:
         assert not message_set.prompt_tone
         assert message_set.fan_speed == 40
         assert message_set.mode == 1
+        assert message_set.pump
+        assert message_set.pump_enable
 
     def test_set_attribute(self) -> None:
         """Test set attribute."""
@@ -134,4 +139,7 @@ class TestMideaA1Device:
             mock_build_send.assert_called()
 
             self.device.set_attribute(DeviceAttributes.swing, True)
+            mock_build_send.assert_called()
+
+            self.device.set_attribute(DeviceAttributes.pump, True)
             mock_build_send.assert_called()

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -34,6 +34,7 @@ class TestMideaA1Device:
         assert self.device.attributes[DeviceAttributes.prompt_tone]
         assert self.device.attributes[DeviceAttributes.fan_speed] == "Medium"
         assert self.device.attributes[DeviceAttributes.target_humidity] == 35
+        assert not self.device.attributes[DeviceAttributes.pump]
 
     def test_modes(self) -> None:
         """Test modes."""
@@ -70,6 +71,7 @@ class TestMideaA1Device:
             mock_message.fan_speed = 40
             mock_message.target_humidity = 40
             mock_message.mode = 1
+            mock_message.pump = True
             mock_message.tank = 60
             mock_message.water_level_set = "50"
             new_status = self.device.process_message(b"")
@@ -77,6 +79,7 @@ class TestMideaA1Device:
             assert not new_status[DeviceAttributes.prompt_tone.value]
             assert new_status[DeviceAttributes.fan_speed.value] == "Low"
             assert new_status[DeviceAttributes.target_humidity.value] == 40
+            assert new_status[DeviceAttributes.pump.value]
             assert new_status[DeviceAttributes.tank_full.value]
             assert new_status[DeviceAttributes.mode.value] == "Manual"
 

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -166,7 +166,7 @@ class TestMessageA1Response:
         body[3] = 0b00000100  # Fan speed (4)
         body[7] = 40  # Target humidity (40)
         body[8] = 0b10000000  # Child lock on (128)
-        body[9] = 0b01000000  # Anion on (64)
+        body[9] = 0b01001000  # Anion on (64), pump on (8)
         body[10] = 0b00111111  # Tank (63)
         body[15] = 50  # Water level set (50)
         body[16] = 45  # Current humidity (45)
@@ -182,6 +182,7 @@ class TestMessageA1Response:
         assert response.target_humidity == 40
         assert hasattr(response, "child_lock")
         assert hasattr(response, "anion")
+        assert hasattr(response, "pump")
         assert hasattr(response, "tank")
         assert response.tank == 63
         assert hasattr(response, "water_level_set")
@@ -242,7 +243,7 @@ class TestMessageA1Response:
         body[3] = 0b00000110  # Fan speed (6)
         body[7] = 40  # Target humidity (40)
         body[8] = 0b10000000  # Child lock on (128)
-        body[9] = 0b01000000  # Anion on (64)
+        body[9] = 0b01000000  # Anion on (64), pump off (0)
         body[10] = 0b00111111  # Tank (63)
         body[15] = 50  # Water level set (50)
         body[16] = 45  # Current humidity (45)
@@ -258,6 +259,7 @@ class TestMessageA1Response:
         assert response.target_humidity == 40
         assert hasattr(response, "child_lock")
         assert hasattr(response, "anion")
+        assert hasattr(response, "pump")
         assert hasattr(response, "tank")
         assert response.tank == 63
         assert hasattr(response, "water_level_set")

--- a/tests/devices/a1/message_a1_test.py
+++ b/tests/devices/a1/message_a1_test.py
@@ -102,6 +102,9 @@ class TestMessageSet:
     def test_set_body(self) -> None:
         """Test set body."""
         msg_set = MessageSet(protocol_version=ProtocolVersion.V1)
+        msg_set.anion = True
+        msg_set.pump = True
+        msg_set.pump_enable = True
 
         expected_body = bytearray([msg_set.body_type]) + bytearray(
             [
@@ -113,7 +116,7 @@ class TestMessageSet:
                 0x00,
                 msg_set.target_humidity,
                 msg_set.child_lock,
-                msg_set.anion,
+                0x58,
                 msg_set.swing,
                 0x00,
                 0x00,
@@ -166,7 +169,7 @@ class TestMessageA1Response:
         body[3] = 0b00000100  # Fan speed (4)
         body[7] = 40  # Target humidity (40)
         body[8] = 0b10000000  # Child lock on (128)
-        body[9] = 0b01001000  # Anion on (64), pump on (8)
+        body[9] = 0b01011000  # Anion on (64), pump enabled (16), pump on (8)
         body[10] = 0b00111111  # Tank (63)
         body[15] = 50  # Water level set (50)
         body[16] = 45  # Current humidity (45)
@@ -183,6 +186,7 @@ class TestMessageA1Response:
         assert hasattr(response, "child_lock")
         assert hasattr(response, "anion")
         assert hasattr(response, "pump")
+        assert hasattr(response, "pump_enable")
         assert hasattr(response, "tank")
         assert response.tank == 63
         assert hasattr(response, "water_level_set")
@@ -243,7 +247,7 @@ class TestMessageA1Response:
         body[3] = 0b00000110  # Fan speed (6)
         body[7] = 40  # Target humidity (40)
         body[8] = 0b10000000  # Child lock on (128)
-        body[9] = 0b01000000  # Anion on (64), pump off (0)
+        body[9] = 0b01010000  # Anion on (64), pump enabled (16), pump off (0)
         body[10] = 0b00111111  # Tank (63)
         body[15] = 50  # Water level set (50)
         body[16] = 45  # Current humidity (45)
@@ -260,6 +264,7 @@ class TestMessageA1Response:
         assert hasattr(response, "child_lock")
         assert hasattr(response, "anion")
         assert hasattr(response, "pump")
+        assert hasattr(response, "pump_enable")
         assert hasattr(response, "tank")
         assert response.tank == 63
         assert hasattr(response, "water_level_set")


### PR DESCRIPTION
## Summary

Adds support for the built-in pump on Midea A1 dehumidifiers.

The pump is exposed as a new A1 device attribute:

- `pump`

The attribute is parsed from normal A1 responses and can also be controlled locally through the classic A1 `0x48` set payload.

## Protocol Evidence

For this A1 dehumidifier, the normal general response reports pump state in `body[9]` bit `0x08`.

App-controlled state matrix:

```text
anion on,  pump on  -> body[9]=0x58 = 0x10 + 0x40 + 0x08
anion on,  pump off -> body[9]=0x50 = 0x10 + 0x40
anion off, pump off -> body[9]=0x10
anion off, pump on  -> body[9]=0x18 = 0x10 + 0x08
```

This shows the pump bit (`0x08`) tracks independently from the existing anion bit (`0x40`).

## Control Evidence

Using the real account for this device, SmartHome cloud returned the exact model Lua script:

```text
T_0000_A1_00000Q15_2023112201.lua
```

That Lua shows pump control uses classic A1 `0x48` set byte 9 with two relevant bits:

```text
water_pump         -> 0x08
water_pump_enable  -> 0x10
```

The Lua builds byte 9 as:

```text
anion | filter | water_pump | water_pump_enable
```

The important detail is preserving the hidden `water_pump_enable` bit (`0x10`) from the parsed response. Earlier probes that only toggled `0x08` did not control the pump; preserving `0x10` makes local control work.

`pump_enable` is kept internal/private so other A1 models do not get a new public attribute or an invented capability bit.

## Changes

- Add `DeviceAttributes.pump`
- Add default A1 pump attribute value of `False`
- Parse pump state from `body[9] & 0x08`
- Preserve hidden pump capability bit from `body[9] & 0x10` for set packets
- Include pump and pump-enable bits in classic A1 `MessageSet` byte 9
- Add A1 tests for default attribute, `process_message`, `make_message_set`, `set_attribute`, general response, and notify response coverage

## Live Validation

Local control was verified against the A1 device:

```text
before pump=True
after target=False pump=False changed=True
```

A separate pump-on command restored the pump state successfully:

```text
before pump=False
after pump=True
```

## Test Validation

```text
.venv/bin/ruff check midealocal/devices/a1 tests/devices/a1
All checks passed
```

```text
.venv/bin/python -m pytest tests/devices/a1
17 passed
```

```text
.venv/bin/python -m pytest tests
159 passed
```

Fixes #445