### PR TITLE
feat(ac): support mixed C1 power analysis

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -49,6 +49,7 @@ class PowerFormats(IntEnum):
     BINARY = 2  # binary with energy in 0.1 kWh resolution
     MIXED = 3  # mixed/INT (byte = 0-99)
     BINARY1 = 12  # binary
+    BCD_ENERGY_BINARY_POWER = 101
 
 
 class NewProtocolQuery(IntEnum):
@@ -1101,11 +1102,15 @@ class XC1MessageBody(MessageBody):
     @classmethod
     def parse_power(cls, analysis_method: int, databytes: bytearray) -> float:
         """AC C1 message body parse power."""
+        if analysis_method == PowerFormats.BCD_ENERGY_BINARY_POWER:
+            return cls.parse_value(PowerFormats.BINARY, databytes) / 10
         return cls.parse_value(analysis_method, databytes) / 10
 
     @classmethod
     def parse_consumption(cls, analysis_method: int, databytes: bytearray) -> float:
         """AC C1 message body parse consumption."""
+        if analysis_method == PowerFormats.BCD_ENERGY_BINARY_POWER:
+            return cls.parse_value(PowerFormats.BCD, databytes) / 100
         # LSB = 0.01 kWh, except for default binary format = 0.1 kWh
         divisor = 10 if analysis_method == PowerFormats.BINARY else 100
         return cls.parse_value(analysis_method, databytes) / divisor

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -15,6 +15,7 @@ from midealocal.devices.ac.message import (
     MessagePowerQuery,
     MessageQuery,
     MessageSubProtocolQuery,
+    PowerFormats,
 )
 
 
@@ -51,6 +52,23 @@ class TestMideaACDevice:
         assert not self.device.attributes[DeviceAttributes.out_silent]
         assert self.device.temperature_step == 1
         assert self.device.fresh_air_fan_speeds is not None
+
+    def test_customize_accepts_bcd_energy_binary_power_format(self) -> None:
+        """Test customize can select BCD energy with binary realtime power."""
+        device = MideaACDevice(
+            name="Custom Power Format Device",
+            device_id=1,
+            ip_address="192.168.1.1",
+            port=12345,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V1,
+            model="test_model",
+            subtype=1,
+            customize='{"power_analysis_method": 101}',
+        )
+
+        assert device._power_analysis_method == PowerFormats.BCD_ENERGY_BINARY_POWER
 
     def test_set_attribute(self) -> None:
         """Test set attribute."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -17,6 +17,7 @@ from midealocal.devices.ac.message import (
     MessageToggleDisplay,
     NewProtocolQuery,
     NewProtocolTags,
+    PowerFormats,
 )
 from midealocal.message import ListTypes, MessageType
 
@@ -711,8 +712,8 @@ class TestMessageACResponse:
         assert hasattr(response, "realtime_power")
         assert response.realtime_power == expected_realtime_power
 
-    def test_message_query_c1_method2(self, method: int = 2) -> None:
-        """Test Message parse query C1 method2 (and 12)."""
+    def _assert_message_query_c1_method2(self, method: int) -> None:
+        """Assert Message parse query C1 method2 (and 12)."""
         self.header[9] = 0x03
         body = bytearray(20)
         body[0] = 0xC1  # Body type
@@ -754,9 +755,50 @@ class TestMessageACResponse:
         assert hasattr(response, "realtime_power")
         assert response.realtime_power == expected_realtime_power
 
+    def test_message_query_c1_method2(self) -> None:
+        """Test Message parse query C1 method2."""
+        self._assert_message_query_c1_method2(2)
+
     def test_message_query_c1_method12(self) -> None:
         """Test Message parse query C1 method12."""
-        self.test_message_query_c1_method2(12)
+        self._assert_message_query_c1_method2(12)
+
+    def test_message_query_c1_bcd_energy_binary_power(self) -> None:
+        """Test C1 format with BCD energy counters and binary realtime watts."""
+        self.header[9] = 0x03
+        samples = [
+            (
+                "c12101440000005800000000000000160016b700000001a9",
+                0.58,
+                0.16,
+                581.5,
+            ),
+            (
+                "c12101440000005900000000000000170016a30000000105",
+                0.59,
+                0.17,
+                579.5,
+            ),
+            (
+                "c12101440000005a000000000000001800162b0000000187",
+                0.60,
+                0.18,
+                567.5,
+            ),
+        ]
+
+        for payload, total_kwh, current_kwh, watts in samples:
+            response = MessageACResponse(
+                self.header + bytearray.fromhex(payload),
+                PowerFormats.BCD_ENERGY_BINARY_POWER,
+            )
+
+            assert hasattr(response, "total_energy_consumption")
+            assert response.total_energy_consumption == total_kwh
+            assert hasattr(response, "current_energy_consumption")
+            assert response.current_energy_consumption == current_kwh
+            assert hasattr(response, "realtime_power")
+            assert response.realtime_power == watts
 
     def test_message_query_c1_method3(self) -> None:
         """Test Message parse query C1 method3."""


### PR DESCRIPTION
## Summary
- add a scoped AC C1 power format for Q1D subtype 524
- decode its C1 energy counters as BCD while decoding realtime power as 24-bit binary / 10
- default Q1D model 00000Q1D subtype 524 to this format while preserving existing customize overrides

## Context
This moves the parser behavior requested from wuwentao/midea_ac_lan#823 into midea-local, where the C1 protocol decoding belongs. The confirmed device reports subtype 524 and model 00000Q1D.

## Tests
- .venv/bin/python -m pytest -q
- .venv/bin/python -m pytest tests/devices/ac -q
- .venv/bin/python -m compileall midealocal tests
- .venv/bin/python -m ruff check midealocal/devices/ac/message.py midealocal/devices/ac/__init__.py tests/devices/ac/message_ac_test.py tests/devices/ac/device_ac_test.py