### PR TITLE
feat(cc): support 0xFE VRF panel protocol (171PNL01/171PANEL)

### DIFF
--- a/midealocal/devices/cc/__init__.py
+++ b/midealocal/devices/cc/__init__.py
@@ -134,6 +134,7 @@ class MideaCCDevice(MideaDevice):
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         if getattr(message, "is_fe_format", False):
             self._is_fe_format = True
+            _LOGGER.debug("[%s] _is_fe_format option True", self.device_id)
         new_status = {}
         fan_speed: int | None = None
         for status in self._attributes:

--- a/midealocal/devices/cc/__init__.py
+++ b/midealocal/devices/cc/__init__.py
@@ -7,7 +7,14 @@ from typing import Any, ClassVar
 from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.device import MideaDevice
 
-from .message import MessageCCResponse, MessageQuery, MessageSet
+from .message import (
+    INDEX_TO_FE_MODE,
+    CCControlId,
+    MessageCCResponse,
+    MessageFEControl,
+    MessageQuery,
+    MessageSet,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,6 +58,17 @@ class MideaCCDevice(MideaDevice):
         0x08: "Medium",
         0x40: "High",
         0x80: "Auto",
+    }
+    # 0xFE VRF panels report fan speed as 1-7 (+8=auto), not as a bitmask
+    _fan_speeds_fe: ClassVar[dict[int, str]] = {
+        0x01: "Level 1",
+        0x02: "Level 2",
+        0x03: "Level 3",
+        0x04: "Level 4",
+        0x05: "Level 5",
+        0x06: "Level 6",
+        0x07: "Level 7",
+        0x08: "Auto",
     }
 
     def __init__(
@@ -98,6 +116,8 @@ class MideaCCDevice(MideaDevice):
             },
         )
         self._fan_speeds: dict[int, str] | None = None
+        # set once a 0xFE-format response is seen; selects the VRF control path
+        self._is_fe_format = False
 
     @property
     def fan_modes(self) -> list[str] | None:
@@ -112,6 +132,8 @@ class MideaCCDevice(MideaDevice):
         """Midea CC device process message."""
         message = MessageCCResponse(msg)
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
+        if getattr(message, "is_fe_format", False):
+            self._is_fe_format = True
         new_status = {}
         fan_speed: int | None = None
         for status in self._attributes:
@@ -126,7 +148,9 @@ class MideaCCDevice(MideaDevice):
             fan_speed is not None
             and self._attributes[DeviceAttributes.fan_speed_level] is not None
         ):
-            if self._fan_speeds is None:
+            if self._is_fe_format:
+                self._fan_speeds = MideaCCDevice._fan_speeds_fe
+            elif self._fan_speeds is None:
                 if self._attributes[DeviceAttributes.fan_speed_level]:
                     self._fan_speeds = MideaCCDevice._fan_speeds_3level
                 else:
@@ -172,6 +196,16 @@ class MideaCCDevice(MideaDevice):
         message.swing = self._attributes[DeviceAttributes.swing]
         return message
 
+    def _fe_temperature_value(self, target_temperature: float) -> int:
+        """Encode a target temperature for the 0xFE control protocol."""
+        return int(target_temperature * 2 + 80) & 0xFF
+
+    def _send_fe_control(self, controls: list[tuple[CCControlId, int]]) -> None:
+        """Build and send a 0xFE key-value control frame."""
+        self.build_send(
+            MessageFEControl(self._message_protocol_version, controls),
+        )
+
     def set_target_temperature(
         self,
         target_temperature: float,
@@ -179,6 +213,19 @@ class MideaCCDevice(MideaDevice):
         zone: int | None = None,  # noqa: ARG002
     ) -> None:
         """Midea CC device set target temperature."""
+        if self._is_fe_format:
+            controls: list[tuple[CCControlId, int]] = []
+            if mode is not None:
+                controls.append((CCControlId.POWER, 1))
+                controls.append((CCControlId.MODE, INDEX_TO_FE_MODE.get(mode, 0x02)))
+            controls.append(
+                (
+                    CCControlId.TARGET_TEMPERATURE,
+                    self._fe_temperature_value(target_temperature),
+                ),
+            )
+            self._send_fe_control(controls)
+            return
         message = self.make_message_set()
         message.target_temperature = target_temperature
         if mode is not None:
@@ -186,8 +233,36 @@ class MideaCCDevice(MideaDevice):
             message.mode = mode
         self.build_send(message)
 
+    def _set_attribute_fe(self, attr: str, value: bool | int | str) -> None:
+        """Set an attribute on a 0xFE VRF panel via key-value control frames."""
+        if attr == DeviceAttributes.power:
+            self._send_fe_control([(CCControlId.POWER, 1 if value else 0)])
+        elif attr == DeviceAttributes.mode:
+            self._send_fe_control(
+                [
+                    (CCControlId.POWER, 1),
+                    (CCControlId.MODE, INDEX_TO_FE_MODE.get(int(value), 0x02)),
+                ],
+            )
+        elif attr == DeviceAttributes.fan_speed:
+            if self._fan_speeds and value in self._fan_speeds.values():
+                speed = list(self._fan_speeds.keys())[
+                    list(self._fan_speeds.values()).index(str(value))
+                ]
+                self._send_fe_control([(CCControlId.FAN_SPEED, speed)])
+        elif attr == DeviceAttributes.eco_mode:
+            self._send_fe_control([(CCControlId.ECO, 1 if value else 0)])
+        elif attr == DeviceAttributes.sleep_mode:
+            self._send_fe_control([(CCControlId.SLEEP, 1 if value else 0)])
+        elif attr == DeviceAttributes.swing:
+            self._send_fe_control([(CCControlId.SWING, 0x06 if value else 0x00)])
+        # other attributes are not supported by the 0xFE control protocol
+
     def set_attribute(self, attr: str, value: bool | int | str) -> None:
         """Midea CC device set attribute."""
+        if self._is_fe_format:
+            self._set_attribute_fe(attr, value)
+            return
         # if nat a sensor
         if attr not in [
             DeviceAttributes.indoor_temperature,

--- a/midealocal/devices/cc/message.py
+++ b/midealocal/devices/cc/message.py
@@ -3,6 +3,7 @@
 from enum import IntEnum
 
 from midealocal.const import DeviceType
+from midealocal.crc8 import calculate
 from midealocal.message import (
     ListTypes,
     MessageBody,
@@ -10,6 +11,13 @@ from midealocal.message import (
     MessageResponse,
     MessageType,
 )
+
+# body[1] format byte that flags the newer VRF panel (171PNL01 / 171PANEL) layout
+FE_FORMAT_BYTE = 0xFE
+# plausibility upper bound (Celsius) for a decoded 0xFE indoor temperature
+MAX_VALID_INDOOR_TEMP = 60
+# vertical louver angle value meaning "auto / oscillating"
+FE_SWING_AUTO = 0x06
 
 
 class CCHeatStatus(IntEnum):
@@ -136,12 +144,94 @@ class MessageSet(MessageCCBase):
         )
 
 
+class CCControlId(IntEnum):
+    """Control ids for the 0xFE VRF panel key-value control protocol."""
+
+    POWER = 0x0000
+    TARGET_TEMPERATURE = 0x0003
+    MODE = 0x0012
+    FAN_SPEED = 0x0015
+    SWING = 0x001C
+    ECO = 0x0028
+    SLEEP = 0x002C
+
+
+class MessageFEControl(MessageRequest):
+    """CC control message for 0xFE VRF panel controllers.
+
+    These devices ignore the legacy C3 ``MessageSet`` command and instead use a
+    key-value (TLV) control frame: for every control a 2-byte big-endian id, a
+    1-byte length, the value bytes and a 0xFF separator, followed by an
+    incrementing message id and a CRC8. The frame layout was reverse-engineered
+    by the msmart-ng project (https://github.com/mill1000/midea-ac-py, MIT).
+    """
+
+    _message_id = 0
+
+    def __init__(
+        self,
+        protocol_version: int,
+        controls: list[tuple[CCControlId, int]],
+    ) -> None:
+        """Initialize CC 0xFE control message."""
+        super().__init__(
+            device_type=DeviceType.CC,
+            protocol_version=protocol_version,
+            message_type=MessageType.set,
+            body_type=ListTypes.X01,
+        )
+        self._controls = controls
+
+    def _next_message_id(self) -> int:
+        MessageFEControl._message_id = (MessageFEControl._message_id + 1) & 0xFF
+        return MessageFEControl._message_id
+
+    @property
+    def body(self) -> bytearray:
+        """Build the full control frame body (no body_type prefix)."""
+        payload = bytearray()
+        for control_id, value in self._controls:
+            payload += int(control_id).to_bytes(2, "big")
+            payload.append(1)
+            payload.append(value & 0xFF)
+            payload.append(0xFF)
+        payload.append(self._next_message_id())
+        payload.append(calculate(payload))
+        return payload
+
+    @property
+    def _body(self) -> bytearray:
+        return bytearray()
+
+
+# 0xFE-format operational_mode (body[31]) -> internal mode index used by the
+# legacy decoder / HA climate (1=fan_only, 2=dry, 3=heat, 4=cool, 5=auto).
+FE_MODE_TO_INDEX = {0x01: 1, 0x06: 2, 0x03: 3, 0x02: 4, 0x05: 5}
+
+# internal mode index -> 0xFE operational_mode value (inverse of FE_MODE_TO_INDEX)
+INDEX_TO_FE_MODE = {1: 0x01, 2: 0x06, 3: 0x03, 4: 0x02, 5: 0x05}
+
+
 class CCGeneralMessageBody(MessageBody):
     """CC message general body."""
 
     def __init__(self, body: bytearray) -> None:
         """Initialize CC message general body."""
         super().__init__(body)
+        # Newer VRF panel controllers (e.g. 171PNL01 / 171PANEL) answer the X01
+        # query with a different payload layout, flagged by the 0xFE format byte
+        # at body[1]. The legacy layout (below) decodes those bytes incorrectly
+        # (indoor_temperature becomes -20, mode is stuck on auto, power is always
+        # on). The 0xFE byte positions used here were reverse-engineered by the
+        # msmart-ng project (https://github.com/mill1000/midea-ac-py, MIT).
+        self.is_fe_format = len(body) > 1 and body[1] == FE_FORMAT_BYTE
+        if self.is_fe_format:
+            self._parse_fe_body(body)
+        else:
+            self._parse_legacy_body(body)
+
+    def _parse_legacy_body(self, body: bytearray) -> None:
+        """Decode the original (pre-0xFE) CC payload layout."""
         self.power = (body[1] & 0x80) > 0
         mode: float = body[1] & 0x1F
         self.mode = 0
@@ -150,7 +240,7 @@ class CCGeneralMessageBody(MessageBody):
             self.mode += 1
         self.fan_speed = body[2]
         self.target_temperature = body[3] + body[19] / 10
-        self.indoor_temperature = (body[4] - 40) / 2
+        self.indoor_temperature: float | None = (body[4] - 40) / 2
         self.eco_mode = (body[13] & 0x01) > 0
         self.sleep_mode = (body[14] & 0x10) > 0
         self.night_light = (body[14] & 0x08) > 0
@@ -161,6 +251,29 @@ class CCGeneralMessageBody(MessageBody):
         self.temperature_precision = 1 if (body[14] & 0x80) > 0 else 0.5
         self.swing = (body[13] & 0x04) > 0
         self.temp_fahrenheit = (body[20] & 0x80) > 0
+
+    def _parse_fe_body(self, body: bytearray) -> None:
+        """Decode the 0xFE VRF panel payload layout (171PNL01 / 171PANEL)."""
+        self.power = bool(body[8])
+        self.target_temperature = (body[11] / 2) - 40
+        # indoor temperature is a 16-bit big-endian value in 0.1 degree units
+        indoor = (body[12] << 8 | body[13]) / 10
+        self.indoor_temperature = indoor if 0 < indoor < MAX_VALID_INDOOR_TEMP else None
+        self.mode = FE_MODE_TO_INDEX.get(body[31], 5)
+        # fan speed is reported as 1-7 (+8=auto), mapped to names by the device
+        self.fan_speed = body[34]
+        self.eco_mode = bool(body[56])
+        self.sleep_mode = bool(body[60])
+        # vertical louver angle: 0x06 == auto (oscillating)
+        self.swing = body[41] == FE_SWING_AUTO
+        self.temp_fahrenheit = bool(body[21])
+        # attributes not present in the 0xFE payload -> safe defaults
+        self.night_light = False
+        self.ventilation = False
+        self.aux_heat_status = 0
+        self.auto_aux_heat_running = False
+        self.fan_speed_level = False
+        self.temperature_precision = 0.5
 
 
 class MessageCCResponse(MessageResponse):

--- a/tests/devices/cc/__init__.py
+++ b/tests/devices/cc/__init__.py
@@ -1,0 +1,1 @@
+"""Test for CC device."""

--- a/tests/devices/cc/message_cc_test.py
+++ b/tests/devices/cc/message_cc_test.py
@@ -1,0 +1,99 @@
+"""Test cc message."""
+
+from midealocal.const import ProtocolVersion
+from midealocal.crc8 import calculate
+from midealocal.devices.cc.message import (
+    CCControlId,
+    CCGeneralMessageBody,
+    MessageFEControl,
+    MessageQuery,
+)
+
+
+class TestCCMessageQuery:
+    """Test CC message query."""
+
+    def test_query_body(self) -> None:
+        """Test query body (body_type byte followed by 23 zero bytes)."""
+        msg = MessageQuery(protocol_version=ProtocolVersion.V3)
+        assert msg.body == bytearray([0x01]) + bytearray([0x00] * 23)
+
+
+class TestCCGeneralMessageBody:
+    """Test CC general message body."""
+
+    def test_legacy_body(self) -> None:
+        """Legacy (non-0xFE) payloads keep the original decoding."""
+        body = bytearray(21)
+        # body[1] is power/mode (not 0xFE) -> legacy path
+        body[1] = 0x80 | 0x04  # power on, mode bit2
+        body[3] = 24  # target temperature integer
+        body[4] = 90  # indoor temperature -> (90 - 40) / 2 = 25
+        message = CCGeneralMessageBody(body)
+        assert message.is_fe_format is False
+        assert message.power is True
+        assert message.indoor_temperature == 25.0
+
+    def test_fe_body(self) -> None:
+        """0xFE VRF panel payloads use the new decoding."""
+        body = bytearray(90)
+        body[0] = 0x01
+        body[1] = 0xFE  # format byte -> 0xFE path
+        body[8] = 1  # power on
+        body[11] = 128  # target temperature -> 128 / 2 - 40 = 24.0
+        body[12] = 0
+        body[13] = 235  # indoor temperature -> 235 / 10 = 23.5
+        body[21] = 0  # celsius
+        body[31] = 0x02  # operational mode COOL -> index 4
+        body[34] = 5  # fan speed level 5
+        body[41] = 0x06  # vertical louver auto -> swing on
+        body[56] = 1  # eco on
+        body[60] = 1  # sleep on
+        message = CCGeneralMessageBody(body)
+        assert message.is_fe_format is True
+        assert message.power is True
+        assert message.target_temperature == 24.0
+        assert message.indoor_temperature == 23.5
+        assert message.mode == 4
+        assert message.fan_speed == 5
+        assert message.swing is True
+        assert message.eco_mode is True
+        assert message.sleep_mode is True
+        assert message.temp_fahrenheit is False
+
+    def test_fe_body_invalid_indoor_temperature(self) -> None:
+        """A zero (no-reading) indoor temperature is reported as None."""
+        body = bytearray(90)
+        body[1] = 0xFE
+        body[12] = 0
+        body[13] = 0  # no reading (device off) -> None rather than 0.0
+        message = CCGeneralMessageBody(body)
+        assert message.indoor_temperature is None
+
+
+class TestMessageFEControl:
+    """Test CC 0xFE key-value control frame."""
+
+    def test_power_control_body(self) -> None:
+        """A single power control builds the expected TLV frame."""
+        MessageFEControl._message_id = 0
+        msg = MessageFEControl(
+            protocol_version=ProtocolVersion.V3,
+            controls=[(CCControlId.POWER, 1)],
+        )
+        payload = bytearray([0x00, 0x00, 0x01, 0x01, 0xFF, 0x01])
+        payload.append(calculate(payload))
+        assert msg.body == payload
+
+    def test_multi_control_body(self) -> None:
+        """Power + mode controls are concatenated in order."""
+        MessageFEControl._message_id = 0
+        msg = MessageFEControl(
+            protocol_version=ProtocolVersion.V3,
+            controls=[(CCControlId.POWER, 1), (CCControlId.MODE, 0x03)],
+        )
+        payload = bytearray(
+            [0x00, 0x00, 0x01, 0x01, 0xFF, 0x00, 0x12, 0x01, 0x03, 0xFF, 0x01],
+        )
+        payload.append(calculate(payload))
+        assert msg.body == payload


### PR DESCRIPTION
## Problem

Newer Midea VRF indoor-unit Wi-Fi panel controllers — models **171PNL01** and **171PANEL** (device type `0xCC`) — do not work with the current CC implementation:

- `indoor_temperature` is reported as **-20 °C**, `mode` is stuck on **auto**, and `power` is always reported **on**
- the device **cannot be controlled** — changing mode or temperature makes the unit beep but nothing actually changes

These controllers are common on Midea multi-split / VRF systems, in particular the **MIH-series indoor units widely installed in Australia** (e.g. `MIH28GHN18`), where each indoor unit has its own Wi-Fi module and is normally driven by an IR remote. The same symptoms are reported in wuwentao/midea_ac_lan#691 and wuwentao/midea_ac_lan#780.

## Root cause

These devices answer the `X01` query with a **different payload layout**, flagged by a `0xFE` format byte at `body[1]`. The existing decoder treats `body[1]` as power/mode (so power/mode are always wrong) and reads the indoor temperature from `body[4]`, which is `0` on these devices → `-20 °C`. They also use a **key-value (TLV) control protocol** instead of the legacy C3 command.

## Changes

Everything is gated on the `0xFE` format byte, so **legacy CC devices are completely unaffected**:

- Decode the `0xFE` payload: power (`body[8]`), target temperature (`body[11]`), indoor temperature (`body[12:13]`, 0.1° units), mode (`body[31]`), fan speed (`body[34]`), eco (`body[56]`), sleep (`body[60]`) and swing (`body[41]`).
- Add `MessageFEControl`, a key-value control frame (2-byte id + length + value + `0xFF`, followed by a message id and a CRC8), reusing the existing `crc8.calculate` helper.
- Route control and the resulting state read-back to the new path only for `0xFE` devices.
- Add unit tests for the new decoding and the control frame.

## Attribution

The `0xFE` byte positions and the TLV control framing were reverse-engineered by the **msmart-ng** project ([mill1000/midea-ac-py](https://github.com/mill1000/midea-ac-py), MIT-licensed). No code was copied — this is an independent implementation using this library's own `crc8` helper.

## Testing

- New unit tests in `tests/devices/cc/` pass.
- Full suite: **177 passed**; `ruff` and `mypy` clean.
- Verified live on a 1-outdoor / 4-indoor VRF system (4 × 171PNL01 / 171PANEL): temperature and state read-back, plus power / mode / target-temperature / fan-speed / eco / sleep / swing control, all confirmed correct.
