### PR TITLE
feat(ac): reflect self-clean running state from device report

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -292,6 +292,10 @@ class MideaACDevice(MideaDevice):
             self._fresh_air_version = DeviceAttributes.fresh_air_1
         elif self._attributes[DeviceAttributes.fresh_air_2] is not None:
             self._fresh_air_version = DeviceAttributes.fresh_air_2
+        if hasattr(message, "self_clean_active"):
+            active = message.self_clean_active
+            self._attributes[DeviceAttributes.self_clean] = active
+            new_status[DeviceAttributes.self_clean.value] = active
         return new_status
 
     def make_message_set(self) -> MessageGeneralSet:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -31,6 +31,7 @@ FROST_PROTECT_MIN_LENGTH = 22
 INDIRECT_WIND_VALUE = 0x02
 MAX_MSG_SERIAL_NUM = 254
 OUT_SILENT_VALUE = 0x03
+SELF_CLEAN_ACTIVE_STATUS_BYTE = 12
 SCREEN_DISPLAY_BYTE_CHECK = 0x07
 SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
@@ -134,6 +135,7 @@ class NewProtocolTags(IntEnum):
     b5_sound = 0x022C
     # AC outdoor silent mode (PortaSplit)
     out_silent = 0x00CD
+    b5_self_clean_active = 0x00E2
 
 
 class MessageACBase(MessageRequest):
@@ -398,6 +400,7 @@ class MessageNewProtocolQuery(MessageACBase):
             NewProtocolTags.out_silent,
             NewProtocolTags.buzzer_all,
             NewProtocolQuery.error_code_query,
+            NewProtocolTags.b5_self_clean_active,
         ]
 
         _body = bytearray([len(query_params)])
@@ -921,6 +924,12 @@ class XBXMessageBody(NewProtocolMessageBody):
             self.sound = params[NewProtocolTags.buzzer_all][0] > 0
         if NewProtocolQuery.error_code_query in params:
             self.error_code = params[NewProtocolQuery.error_code_query][0]
+        if NewProtocolTags.b5_self_clean_active in params:
+            data = params[NewProtocolTags.b5_self_clean_active]
+            self.self_clean_active: bool = (
+                len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
+                and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
+            )
 
 
 class XB5MessageBody(NewProtocolMessageBody):

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -265,6 +265,34 @@ class TestMideaACDevice:
             self.device.set_swing(True, False)
             mock_build_send.assert_called()
 
+    def test_self_clean_syncs_from_self_clean_active(self) -> None:
+        """Test that self_clean attribute tracks self_clean_active status reports."""
+        with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.power = False
+            mock_message.fresh_air_power = False
+            mock_message.fresh_air_fan_speed = 0
+            mock_message.fresh_air_1 = None
+            mock_message.fresh_air_2 = None
+            mock_message.swing_vertical = False
+            mock_message.indoor_temperature = None
+            mock_message.outdoor_temperature = None
+            mock_message.indoor_humidity = None
+            mock_message.total_energy_consumption = None
+            mock_message.current_energy_consumption = None
+            mock_message.realtime_power = None
+
+            mock_message.self_clean_active = True
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.self_clean.value] is True
+            assert self.device.attributes[DeviceAttributes.self_clean] is True
+
+            mock_message.self_clean_active = False
+            result = self.device.process_message(b"")
+            assert result[DeviceAttributes.self_clean.value] is False
+            assert self.device.attributes[DeviceAttributes.self_clean] is False
+
     def test_invalid_customize_format(self) -> None:
         """Test invalid customize format."""
         self.device.set_customize("{")

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -636,8 +636,8 @@ class TestMessageACResponse:
         body += bytearray(
             [
                 NewProtocolTags.b5_self_clean_active & 0xFF,  # tag low 0xE2
-                NewProtocolTags.b5_self_clean_active >> 8,    # tag high 0x00
-                len(payload),                                  # length 39
+                NewProtocolTags.b5_self_clean_active >> 8,  # tag high 0x00
+                len(payload),  # length 39
             ],
         )
         body += payload

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -189,7 +189,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0B,
+                0x0C,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -212,6 +212,8 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.buzzer_all >> 8,
                 NewProtocolQuery.error_code_query & 0xFF,
                 NewProtocolQuery.error_code_query >> 8,
+                NewProtocolTags.b5_self_clean_active & 0xFF,
+                NewProtocolTags.b5_self_clean_active >> 8,
             ],
         )
         assert msg.body[:-2] == expected_body
@@ -614,6 +616,36 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "out_silent")
         assert response.out_silent is expected
+
+    @pytest.mark.parametrize(
+        ("byte12", "expected"),
+        [(0x3C, True), (0x00, False)],
+    )
+    def test_message_notify2_b5_self_clean_active(
+        self,
+        byte12: int,
+        expected: bool,
+    ) -> None:
+        """Test Message parse notify2 B5 with self_clean_active."""
+        # B5 push body: body_type(1) + count(1) + tag(2) + length(1) + value(39)
+        payload = bytearray(39)
+        payload[12] = byte12
+        body = bytearray(2)
+        body[0] = 0xB5  # Body type
+        body[1] = 0x01  # Params count
+        body += bytearray(
+            [
+                NewProtocolTags.b5_self_clean_active & 0xFF,  # tag low 0xE2
+                NewProtocolTags.b5_self_clean_active >> 8,    # tag high 0x00
+                len(payload),                                  # length 39
+            ],
+        )
+        body += payload
+        body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "self_clean_active")
+        assert response.self_clean_active is expected
 
     def test_message_query_c0(self) -> None:
         """Test Message parse query C0."""


### PR DESCRIPTION
  Follow-up to #444 — self-clean running state
  
  The previous PR noted that self_clean had no "in progress" status bit. After further investigation with a live device, tag 0x00E2 (b5_self_clean_active) carries exactly that: the actual running state
  of the self-clean cycle, pushed periodically as a B5 notify2 message.

  This PR wires it up so self_clean reflects reality rather than just the last command sent.

  Protocol details

  - Tag 0x00E2 is returned in B5 push messages (message type notify2) and also queryable via NewProtocolQuery
  - The value is a 39-byte payload; byte 12 is non-zero while the cycle is running, 0x00 when idle
  - The same tag name b5_self_clean_active already exists logically in the protocol — it just wasn't queried or parsed

  Behaviour after this change

  - Setting self_clean = True sends the trigger command (unchanged from #444)
  - The device then pushes b5_self_clean_active reports; self_clean updates in real time to match
  - When the cycle ends naturally or is cancelled, the device reports 0x00 and self_clean resets to False automatically
  - No separate self_clean_active attribute is introduced — self_clean serves as both control and live status

  Changes

  - Add b5_self_clean_active = 0x00E2 to NewProtocolTags
  - Include it in MessageNewProtocolQuery
  - Parse byte 12 of the B5 response in XBXMessageBody into self_clean_active on the message object
  - In process_message, map message.self_clean_active → DeviceAttributes.self_clean

  Testing

  Verified on a PortaSplit:
  - self_clean goes True within ~6 s of triggering (first notify2 push)
  - self_clean goes False when the cycle completes or is cancelled
  - Behaviour confirmed both when starting from device-OFF and device-ON states