### PR TITLE
fix(cloud): send applianceCodes in getToken for SmartHome LAN tokens

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -266,7 +266,11 @@ class MideaCloud:
         for method in [1, 2]:
             udp_id = self._security.get_udp_id(appliance_id, method)
             data = self._make_general_data()
-            data.update({"udpid": udp_id})
+            # The MSmartHome ("SmartHome") cloud rejects getToken with
+            # 3004 "value is illegal" unless the appliance id is also sent as
+            # `applianceCodes`; the official app includes it. Harmless on other
+            # clouds, which ignore the extra field.
+            data.update({"udpid": udp_id, "applianceCodes": str(appliance_id)})
             response = await self._api_request(
                 endpoint="/v1/iot/secure/getToken",
                 data=data,


### PR DESCRIPTION
## Problem

On the MSmartHome / "SmartHome" cloud, `MideaCloud.get_cloud_keys()` always fails with:

```json
{"code":"3004","msg":"value is illegal."}
```

`login()` and `list_appliances()` work, but `/v1/iot/secure/getToken` is rejected, so V3 devices never receive a LAN `token`/`key` and can't be added for local control ("device auth failed" / no devices addable).

## Root cause

The MSmartHome app sends an extra field in the getToken body — **`applianceCodes`** (the appliance id, as a string) — alongside `udpid`. `midea-local` omits it, and the cloud rejects the request as "value is illegal."

It is **not** a udpid problem: every udpid derivation (`REVERSED_BIG`/`BIG`/`LITTLE`) returns the same `3004` *without* `applianceCodes`, and any of them works *with* it. I confirmed this by capturing the official app's real getToken request (it includes `"applianceCodes":"<device_id>"`) and reproducing it with this library's own session.

## Fix

```python
data.update({"udpid": udp_id, "applianceCodes": str(appliance_id)})
```

## Verification

Tested live against the SmartHome cloud with a real account and 4 V3 air conditioners (type `0xAC`). Identical result for all devices:

| request | result |
|---|---|
| without `applianceCodes` | `3004 "value is illegal."` |
| **with `applianceCodes`** | `code 0`, valid `tokenlist` with `token`+`key` |

The returned token/key authenticate over the local V3 (8370) handshake (`connect()` + `authenticate()` succeed), giving full local control.

## Notes

- `applianceCodes` is an extra body field; clouds that don't require it should ignore it. I could only test the SmartHome cloud — if there's any concern about Meiju / MideaAir / NetHomePlus, I'm happy to move this into a `SmartHomeCloud` override instead.
- No public API change; `get_cloud_keys` signature is unchanged.

---

While tracking this down I also put together a small standalone helper that applies this fix to fetch tokens, plus a write-up of how the missing field was found (Android emulator + Frida + a UDP discovery relay): https://github.com/cauan/midea-local-tokens — in case it's useful for repro.
