### PR TITLE
feat(e2): support heating power multiplier

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 from enum import IntEnum, StrEnum
 from typing import Any
 
@@ -203,7 +204,7 @@ class MideaE2Device(MideaDevice):
                     and value is not None
                     and self._heating_power_multiplier != 1.0
                 ):
-                    value *= self._heating_power_multiplier
+                    value = round(value * self._heating_power_multiplier)
                 self._attributes[status] = value
                 new_status[str(status)] = value
         return new_status
@@ -261,9 +262,11 @@ class MideaE2Device(MideaDevice):
                 if params and "precision_halves" in params:
                     self._precision_halves = params.get("precision_halves")
                 if params and "heating_power_multiplier" in params:
-                    self._heating_power_multiplier = float(
+                    heating_power_multiplier = float(
                         params.get("heating_power_multiplier"),
                     )
+                    if math.isfinite(heating_power_multiplier):
+                        self._heating_power_multiplier = heating_power_multiplier
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all(

--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -159,6 +159,8 @@ class MideaE2Device(MideaDevice):
         self._default_temperature_step = 1.0
         self._precision_halves: bool | None = None
         self._default_precision_halves = False
+        self._default_heating_power_multiplier = 1.0
+        self._heating_power_multiplier = self._default_heating_power_multiplier
         self.set_customize(customize)
 
     @property
@@ -195,8 +197,15 @@ class MideaE2Device(MideaDevice):
         new_status = {}
         for status in self._attributes:
             if hasattr(message, str(status)):
-                self._attributes[status] = getattr(message, str(status))
-                new_status[str(status)] = getattr(message, str(status))
+                value = getattr(message, str(status))
+                if (
+                    status == DeviceAttributes.heating_power
+                    and value is not None
+                    and self._heating_power_multiplier != 1.0
+                ):
+                    value *= self._heating_power_multiplier
+                self._attributes[status] = value
+                new_status[str(status)] = value
         return new_status
 
     def make_message_set(self) -> MessageSet:
@@ -239,6 +248,7 @@ class MideaE2Device(MideaDevice):
         self._old_protocol = self._default_old_protocol
         self._temperature_step = self._default_temperature_step
         self._precision_halves = self._default_precision_halves
+        self._heating_power_multiplier = self._default_heating_power_multiplier
         if customize and len(customize) > 0:
             try:
                 params = json.loads(customize)
@@ -250,6 +260,10 @@ class MideaE2Device(MideaDevice):
                     self._temperature_step = float(params.get("temperature_step"))
                 if params and "precision_halves" in params:
                     self._precision_halves = params.get("precision_halves")
+                if params and "heating_power_multiplier" in params:
+                    self._heating_power_multiplier = float(
+                        params.get("heating_power_multiplier"),
+                    )
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all(
@@ -257,6 +271,7 @@ class MideaE2Device(MideaDevice):
                     "temperature_step": self._temperature_step,
                     "old_protocol": self._old_protocol,
                     "precision_halves": self._precision_halves,
+                    "heating_power_multiplier": self._heating_power_multiplier,
                 },
             )
 

--- a/tests/devices/e2/__init__.py
+++ b/tests/devices/e2/__init__.py
@@ -1,0 +1,1 @@
+"""E2 device tests."""

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -51,4 +51,34 @@ class TestMideaE2Device:
             status = device.process_message(b"")
 
         assert status[DeviceAttributes.heating_power.value] == expected_power
+        assert isinstance(status[DeviceAttributes.heating_power.value], int)
         assert device.attributes[DeviceAttributes.heating_power] == expected_power
+
+    @pytest.mark.parametrize(
+        "customize",
+        [
+            '{"heating_power_multiplier": "nan"}',
+            '{"heating_power_multiplier": "inf"}',
+            '{"heating_power_multiplier": "-inf"}',
+        ],
+    )
+    def test_process_message_ignores_non_finite_heating_power_multiplier(
+        self,
+        customize: str,
+    ) -> None:
+        """Non-finite multipliers are ignored to keep published values valid."""
+
+        class FakeMessage:
+            heating_power = 2000
+
+        device = self._device(customize)
+
+        with patch(
+            "midealocal.devices.e2.MessageE2Response",
+            return_value=FakeMessage(),
+        ):
+            status = device.process_message(b"")
+
+        assert status[DeviceAttributes.heating_power.value] == 2000
+        assert isinstance(status[DeviceAttributes.heating_power.value], int)
+        assert device.attributes[DeviceAttributes.heating_power] == 2000

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -1,0 +1,54 @@
+"""Test E2 Device."""
+
+from unittest.mock import patch
+
+import pytest
+
+from midealocal.const import ProtocolVersion
+from midealocal.devices.e2 import DeviceAttributes, MideaE2Device
+
+
+class TestMideaE2Device:
+    """Test Midea E2 Device."""
+
+    def _device(self, customize: str = "") -> MideaE2Device:
+        return MideaE2Device(
+            name="Test Device",
+            device_id=1,
+            ip_address="192.168.1.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V1,
+            model="test_model",
+            subtype=1,
+            customize=customize,
+        )
+
+    @pytest.mark.parametrize(
+        ("customize", "expected_power"),
+        [
+            ("", 2000),
+            ('{"heating_power_multiplier": 0.75}', 1500),
+        ],
+    )
+    def test_process_message_applies_heating_power_multiplier(
+        self,
+        customize: str,
+        expected_power: int,
+    ) -> None:
+        """E2 heating power can be calibrated while preserving the default."""
+
+        class FakeMessage:
+            heating_power = 2000
+
+        device = self._device(customize)
+
+        with patch(
+            "midealocal.devices.e2.MessageE2Response",
+            return_value=FakeMessage(),
+        ):
+            status = device.process_message(b"")
+
+        assert status[DeviceAttributes.heating_power.value] == expected_power
+        assert device.attributes[DeviceAttributes.heating_power] == expected_power


### PR DESCRIPTION
## Summary
- Add an optional E2 `heating_power_multiplier` customize setting.
- Apply the multiplier only to reported E2 heating power, preserving the current default behavior with `1.0`.
- Add E2 device tests for default and calibrated heating power values.

## Motivation
Some E2 electric water heaters report a nominal heating power that does not match measured real-world power. This option lets users calibrate the exposed heating power sensor without changing behavior for existing installations.

Example customize value:
```json
{"heating_power_multiplier": 0.75}
```

## Tests
- `.venv/bin/python -m ruff check midealocal/devices/e2/__init__.py tests/devices/e2`
- `.venv/bin/python -m pytest tests/devices/e2/device_e2_test.py tests/devices/cd/device_cd_test.py tests/devices/c3/device_c3_test.py`