### PR TITLE
feat(e2): add memory (Memo U) attribute support

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -55,6 +55,7 @@ class DeviceAttributes(StrEnum):
     sterilization = "sterilization"
     heat_water_level = "heat_water_level"
     eplus = "eplus"
+    memory = "memory"
     fast_wash = "fast_wash"
     half_heat = "half_heat"
     summer = "summer"
@@ -126,6 +127,7 @@ class MideaE2Device(MideaDevice):
                 DeviceAttributes.sterilization: None,
                 DeviceAttributes.heat_water_level: None,
                 DeviceAttributes.eplus: None,
+                DeviceAttributes.memory: None,
                 DeviceAttributes.fast_wash: None,
                 DeviceAttributes.half_heat: None,
                 DeviceAttributes.summer: None,

--- a/midealocal/devices/e2/message.py
+++ b/midealocal/devices/e2/message.py
@@ -12,6 +12,7 @@ from midealocal.message import (
 HEATING_POWER_BYTE = 34
 PROTECTION_BYTE = 22
 WATER_CONSUMPTION_BYTE = 25
+MEMORY_BYTE = 23
 
 
 class MessageE2Base(MessageRequest):
@@ -97,11 +98,16 @@ class MessageNewProtocolSet(MessageE2Base):
         self.always_fell: bool | None = None
         self.smart_sterilize: bool | None = None
         self.uv_sterilize: bool | None = None
+        self.memory: bool | None = None
 
     @property
     def _body(self) -> bytearray:
         byte12 = 0x00
         byte13 = 0x00
+        # memory (Memo U): "mode" command 0x03, flag on the 4th body byte (0x80)
+        if self.memory is not None:
+            value = 0x80 if self.memory else 0x00
+            return bytearray([0x03, 0x00, 0x00, value, 0x00, 0x00, 0x00, 0x00, 0x00])
         if self.target_temperature is not None:
             byte12 = 0x07
             byte13 = int(self.target_temperature) & 0xFF
@@ -250,6 +256,8 @@ class E2GeneralMessageBody(MessageBody):
         self.protection = (
             ((body[22] & 0x02) > 0) if len(body) > PROTECTION_BYTE else False
         )
+        # memory (Memo U): smart memory boost mode
+        self.memory = (body[23] & 0x08) > 0 if len(body) > MEMORY_BYTE else None
         # waterday_lowbyte/waterday_highbyte
         if len(body) > WATER_CONSUMPTION_BYTE:
             self.day_water_consumption = body[20] + (body[21] << 8)


### PR DESCRIPTION
Adds the E2 `memory` attribute — the feature shown as **"Memo U"** in the MSmart app — with both read and write support.

- **Read:** status bit `body[23] & 0x08`
- **Write:** new-protocol *mode* command `byte12 = 0x03` with the flag carried by the 4th body byte (`0x80` = on, `0x00` = off)

Decoded from the official **`T_0000_E2_24.lua`** plugin (same source as the E2 attrs added in #371) and **verified on real hardware** (E2 model `5100077J`, new protocol):

| Action | Frame | Result |
|---|---|---|
| read OFF | query | `body[23]&0x08 = 0` |
| read ON | query | `body[23]&0x08 = 8` |
| turn ON | `[0x03,0,0,0x80,0,0,0,0,0]` | bit 0→8, target →75 ✅ |
| turn OFF | `[0x03,0,0,0,0,0,0,0,0]` | bit 8→0 ✅ |

Required by wuwentao/midea_ac_lan#849 (exposes Memo U as a switch).

📎 The decrypted `T_0000_E2_24.lua` is attached below for verification.

https://gist.github.com/Pulpyyyy/35e61ec35fafd51d6681969c271fbd95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
