### PR TITLE
feat(ac): decode B5 capabilities into feature flags

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -308,9 +308,13 @@ class MideaACDevice(MideaDevice):
             self._attributes[DeviceAttributes.self_clean] = active
             new_status[DeviceAttributes.self_clean.value] = active
         new_status.update(self._refresh_temperature_limits(message))
-        if hasattr(message, "capabilities") and message.capabilities:
-            self._capabilities.update(message.capabilities)
+        self._update_capabilities(message)
         return new_status
+
+    def _update_capabilities(self, message: MessageACResponse) -> None:
+        """Accumulate decoded B5 capability flags from a B5 response."""
+        if hasattr(message, "capabilities"):
+            self._capabilities.update(message.capabilities)
 
     @property
     def capabilities(self) -> dict[str, bool]:

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -195,6 +195,8 @@ class MideaACDevice(MideaDevice):
         self._bb_timer: bool = False
         # per-mode setpoint limits from the B5 capability, keyed by mode value
         self._temperature_limits: dict[int, tuple[float, float]] | None = None
+        # decoded B5 capability flags (accumulated across B5 frames)
+        self._capabilities: dict[str, bool] = {}
         # manual setpoint limits from customize (highest priority)
         self._customize_min_temperature: float | None = None
         self._customize_max_temperature: float | None = None
@@ -306,7 +308,14 @@ class MideaACDevice(MideaDevice):
             self._attributes[DeviceAttributes.self_clean] = active
             new_status[DeviceAttributes.self_clean.value] = active
         new_status.update(self._refresh_temperature_limits(message))
+        if hasattr(message, "capabilities") and message.capabilities:
+            self._capabilities.update(message.capabilities)
         return new_status
+
+    @property
+    def capabilities(self) -> dict[str, bool]:
+        """Return the decoded B5 capability flags reported by the device."""
+        return self._capabilities
 
     def _b5_temperature_limits(self) -> tuple[float, float] | None:
         """Return the B5 setpoint limits for the current mode, if any.

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -52,6 +52,8 @@ B5_LOW_VALUE_MAX = 2  # value < 2 -> vertical swing / cool turbo available
 B5_FAN_LOW_HIGH_VALUES = frozenset({3, 4, 5, 6, 7})
 B5_FAN_MEDIUM_VALUES = frozenset({5, 6, 7})
 B5_FAN_AUTO_VALUES = frozenset({4, 5, 6})
+B5_FAN_SILENT_VALUE = 6
+B5_FAN_CUSTOM_VALUE = 1
 B5_ECO_VALUES = frozenset({1, 2})
 B5_ANION_ON_VALUE = 1
 B5_TURBO_HEAT_VALUES = frozenset({1, 3})
@@ -1011,10 +1013,12 @@ class XB5MessageBody(NewProtocolMessageBody):
             caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
         if NewProtocolTags.b5_wind_speed in params:
             value = params[NewProtocolTags.b5_wind_speed][0]
+            caps["fan_silent"] = value == B5_FAN_SILENT_VALUE
             caps["fan_low"] = value in B5_FAN_LOW_HIGH_VALUES
             caps["fan_medium"] = value in B5_FAN_MEDIUM_VALUES
             caps["fan_high"] = value in B5_FAN_LOW_HIGH_VALUES
             caps["fan_auto"] = value in B5_FAN_AUTO_VALUES
+            caps["fan_custom"] = value == B5_FAN_CUSTOM_VALUE
         if NewProtocolTags.b5_eco in params:
             caps["eco"] = params[NewProtocolTags.b5_eco][0] in B5_ECO_VALUES
         if NewProtocolTags.b5_anion in params:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -41,6 +41,22 @@ XC1_SUBBODY_TYPE_44 = 0x44
 XC1_SUBBODY_TYPE_40 = 0x40
 XC1_SUBBODY_TYPE_45 = 0x45
 
+# B5 capability value semantics (reverse-engineered; see _parse_capabilities).
+# The raw byte of each capability is not a 0/1 flag; each has its own value set.
+B5_HEAT_MODE_VALUES = frozenset({1, 2, 4, 6, 7, 9, 10, 11, 12, 13})
+B5_NO_COOL_MODE_VALUES = frozenset({2, 10, 12})
+B5_DRY_MODE_VALUES = frozenset({0, 1, 5, 6, 9, 11, 13})
+B5_AUTO_MODE_VALUES = frozenset({0, 1, 2, 7, 8, 9, 13})
+B5_SWING_HORIZONTAL_VALUES = frozenset({1, 3})
+B5_LOW_VALUE_MAX = 2  # value < 2 -> vertical swing / cool turbo available
+B5_FAN_LOW_HIGH_VALUES = frozenset({3, 4, 5, 6, 7})
+B5_FAN_MEDIUM_VALUES = frozenset({5, 6, 7})
+B5_FAN_AUTO_VALUES = frozenset({4, 5, 6})
+B5_ECO_VALUES = frozenset({1, 2})
+B5_ANION_ON_VALUE = 1
+B5_TURBO_HEAT_VALUES = frozenset({1, 3})
+B5_DISPLAY_VALUES = frozenset({1, 2, 100})
+
 
 class PowerFormats(IntEnum):
     """AC Power/Energy analysis formats."""
@@ -973,6 +989,44 @@ class XB5MessageBody(NewProtocolMessageBody):
             self.b5_sound = params[NewProtocolTags.b5_sound][0]
         if NewProtocolTags.b5_humidity in params:
             self.b5_humidity = params[NewProtocolTags.b5_humidity][0]
+        self._parse_capabilities(params)
+
+    def _parse_capabilities(self, params: dict[int, bytearray]) -> None:
+        """Decode B5 capability values into feature flags.
+
+        The raw byte of each capability is not a simple 0/1 flag; each one has
+        its own value semantics (reverse-engineered, matching the msmart
+        project). Only capabilities actually reported are added.
+        """
+        caps: dict[str, bool] = {}
+        if NewProtocolTags.b5_mode in params:
+            value = params[NewProtocolTags.b5_mode][0]
+            caps["heat_mode"] = value in B5_HEAT_MODE_VALUES
+            caps["cool_mode"] = value not in B5_NO_COOL_MODE_VALUES
+            caps["dry_mode"] = value in B5_DRY_MODE_VALUES
+            caps["auto_mode"] = value in B5_AUTO_MODE_VALUES
+        if NewProtocolTags.b5_wind_swing in params:
+            value = params[NewProtocolTags.b5_wind_swing][0]
+            caps["swing_horizontal"] = value in B5_SWING_HORIZONTAL_VALUES
+            caps["swing_vertical"] = value < B5_LOW_VALUE_MAX
+        if NewProtocolTags.b5_wind_speed in params:
+            value = params[NewProtocolTags.b5_wind_speed][0]
+            caps["fan_low"] = value in B5_FAN_LOW_HIGH_VALUES
+            caps["fan_medium"] = value in B5_FAN_MEDIUM_VALUES
+            caps["fan_high"] = value in B5_FAN_LOW_HIGH_VALUES
+            caps["fan_auto"] = value in B5_FAN_AUTO_VALUES
+        if NewProtocolTags.b5_eco in params:
+            caps["eco"] = params[NewProtocolTags.b5_eco][0] in B5_ECO_VALUES
+        if NewProtocolTags.b5_anion in params:
+            caps["anion"] = params[NewProtocolTags.b5_anion][0] == B5_ANION_ON_VALUE
+        if NewProtocolTags.b5_strong_wind in params:
+            value = params[NewProtocolTags.b5_strong_wind][0]
+            caps["turbo_cool"] = value < B5_LOW_VALUE_MAX
+            caps["turbo_heat"] = value in B5_TURBO_HEAT_VALUES
+        if NewProtocolTags.b5_screen_display in params:
+            value = params[NewProtocolTags.b5_screen_display][0]
+            caps["display_control"] = value in B5_DISPLAY_VALUES
+        self.capabilities = caps
 
 
 class XC0MessageBody(XMessageBody):


### PR DESCRIPTION
## Summary
Decode the AC **B5 capability** values into boolean feature flags, exposed via a new `MideaACDevice.capabilities` property. The B5 response is already queried (`MessageCapabilitiesQuery` in `build_query`) and parsed by `XB5MessageBody` — this PR adds the *interpretation* of the values.

## Why
The raw B5 byte of each capability is **not** a 0/1 flag — each one has its own value semantics (reverse-engineered, matching the `msmart` project). Decoding them lets a consumer know what the device really supports:
- modes: `heat` / `cool` / `dry` / `auto`
- swing: horizontal / vertical
- fan: silent / low / medium / high / auto / custom
- `eco`, `anion`, `turbo` (cool/heat), `display`

## Non-regression (important)
- **Purely additive**: a new `capabilities` dict (populated only from B5) + `MideaACDevice.capabilities`. No existing parsing/attribute is changed.
- Devices that don't report B5 → `capabilities == {}` → consumers fall back to their defaults. **No behaviour change for existing devices.**
- `mypy` (strict) passes; lines ≤ 88.

## Verified on real hardware
Tested on a cooling-only portable AC (model `00000Q17`). The decode reconciles **9/9** with what the unit actually accepts/rejects (cool/dry/fan, low/high/auto fan, no swing, no eco/turbo, 17–30 °C). Decrypted Lua plugin used as reference: https://gist.github.com/Pulpyyyy/02d3d42d62ab17c10ab3f799b00fdf61

## Companion PR
`wuwentao/midea_ac_lan` consumes `capabilities` to align the climate entity (hvac_modes / fan_modes / swing / presets) — opened separately: wuwentao/midea_ac_lan#862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
