### PR TITLE
feat: report MAC address

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -120,6 +120,7 @@ class MideaCLI:
                     model=device["model"],
                     subtype=0,
                     customize="",
+                    mac=device["mac"],
                 )
                 _LOGGER.debug("Opening socket for device.")
                 if dev.connect():

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections.abc import Callable
 from enum import IntEnum, StrEnum
-from typing import Any, ClassVar, TypedDict, Unpack
+from typing import Any, ClassVar, NotRequired, TypedDict, Unpack
 
 from typing_extensions import deprecated
 
@@ -83,6 +83,7 @@ class MideaDeviceInitKwargs(TypedDict):
     device_protocol: ProtocolVersion
     model: str
     subtype: int
+    mac: NotRequired[str | None]
 
 
 class MideaDevice(threading.Thread):
@@ -123,6 +124,7 @@ class MideaDevice(threading.Thread):
         self._previous_refresh = 0.0
         self._previous_heartbeat = 0.0
         self.name = self._device_name
+        self.set_mac(kwargs.get("mac"))
 
     _fahrenheit_default: ClassVar[bool] = False
 
@@ -197,6 +199,11 @@ class MideaDevice(threading.Thread):
     def subtype(self) -> int:
         """Device subtype."""
         return self._subtype
+
+    @property
+    def mac(self) -> str | None:
+        """Device MAC address."""
+        return self._mac
 
     @staticmethod
     def fetch_v2_message(msg: bytes) -> tuple[list, bytes]:
@@ -647,6 +654,10 @@ class MideaDevice(threading.Thread):
             _LOGGER.debug("[%s] Update IP address to %s", self._device_id, ip_address)
             self._ip_address = ip_address
             self.close_socket()
+
+    def set_mac(self, mac: str | None) -> None:
+        """Set MAC."""
+        self._mac = mac or None
 
     def set_refresh_interval(self, refresh_interval: int) -> None:
         """Set refresh interval."""

--- a/midealocal/devices/__init__.py
+++ b/midealocal/devices/__init__.py
@@ -19,6 +19,7 @@ def device_selector(
     model: str,
     subtype: int,
     customize: str,
+    mac: str | None = None,
 ) -> MideaDevice:
     """Select and load device."""
     try:
@@ -38,6 +39,7 @@ def device_selector(
             model=model,
             subtype=subtype,
             customize=customize,
+            mac=mac,
         )
     except ModuleNotFoundError:
         device = None

--- a/midealocal/discover.py
+++ b/midealocal/discover.py
@@ -1,6 +1,7 @@
 """Midea local discover."""
 
 import logging
+import re
 import socket
 from ipaddress import IPv4Network
 from typing import Any
@@ -159,6 +160,35 @@ SERIAL_TYPE2_LENGTH = 22
 DISCOVERY_MIN_REPLY_LENGTH = 41
 
 
+def _extract_mac(reply: bytes | bytearray, ssid_len: int, sn: str) -> str | None:
+    """Return the MAC address or None if not available.
+
+    Extracts the MAC address from the v3 discover reply and returns it as a
+    hexadecimal string without internal separators.
+    If the reply does not provide the MAC address, the MAC is extracted from
+    the serial number, which also may contain the MAC address.
+    Otherwise return None.
+    """
+    # Based on https://github.com/nbogojevic/midea-beautiful-air/blob/db3622e784891af0a522d70a626fb54e5c3e5e6f/midea_beautiful/lan.py#L264  # noqa: E501
+    mac = None
+    mac_start = 63 + ssid_len
+    mac_ends = mac_start + 6
+    if len(reply) >= mac_ends:
+        mac = reply[mac_start:mac_ends].hex()
+    elif len(sn) == SERIAL_TYPE1_LENGTH:
+        mac = sn[16:28]
+    elif len(sn) == SERIAL_TYPE2_LENGTH:
+        # MAC address not reported
+        mac = None
+    else:
+        _LOGGER.warning("Unknown serial number format %s", sn)
+        mac = None
+    if mac and not re.fullmatch(r"[0-9A-Fa-f]{12}", mac):
+        _LOGGER.warning("Invalid MAC address %s", mac)
+        mac = None
+    return mac
+
+
 def _parse_discover_response(
     sock: socket.socket,
     found_devices: dict[int, dict[str, Any]],
@@ -190,13 +220,15 @@ def _parse_discover_response(
             40
         ] + DISCOVERY_MIN_REPLY_LENGTH <= len(reply):
             _LOGGER.debug("Declassified reply: %s", reply.hex())
+            ssid_len = reply[40]
             ssid = reply[
-                DISCOVERY_MIN_REPLY_LENGTH : DISCOVERY_MIN_REPLY_LENGTH + reply[40]
-            ].decode("utf-8")
+                DISCOVERY_MIN_REPLY_LENGTH : DISCOVERY_MIN_REPLY_LENGTH + ssid_len
+            ].decode("ascii")
             device_type = ssid.split("_")[1]
             port = bytes2port(reply[4:8])
-            model = reply[17:25].decode("utf-8")
-            sn = reply[8:40].decode("utf-8")
+            model = reply[17:25].decode("ascii")
+            sn = reply[8:40].decode("ascii")
+            mac = _extract_mac(reply, ssid_len, sn)
         else:
             _LOGGER.warning(
                 "Failed to decrypt the encrypt_data: %s from %s. Maybe not support.",
@@ -226,6 +258,7 @@ def _parse_discover_response(
             model = sn[3:11]
         else:
             model = ""
+        mac = _extract_mac(b"", 0, sn)
     else:
         return 0, None
     return device_id, {
@@ -236,6 +269,7 @@ def _parse_discover_response(
         "model": model,
         "sn": sn,
         "protocol": protocol,
+        "mac": mac,
     }
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -16,6 +16,7 @@ from midealocal.cli import (
 from midealocal.cloud import MideaAirCloud, SmartHomeCloud
 from midealocal.const import ProtocolVersion
 from midealocal.device import AuthException, NoSupportedProtocol
+from midealocal.discover import _extract_mac
 from midealocal.exceptions import SocketException
 
 
@@ -102,6 +103,24 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             mock_default_keys.assert_called_once()
             mock_cloud_keys.assert_not_called()
 
+    def test_extract_mac(self) -> None:
+        """Test _extract_mac."""
+        expected_mac = "1234567890ab"
+        mac = _extract_mac(
+            reply=b"",
+            ssid_len=0,
+            sn="a" * 16 + expected_mac + "1234",
+        )
+        assert mac == expected_mac
+        mac2 = _extract_mac(
+            reply=b"a" * 63 + b"bb" + b"\x12\x34\x56\x78\x90\xab",
+            ssid_len=2,
+            sn="a" * 16 + expected_mac + "1234",
+        )
+        assert mac2 == expected_mac
+        mac3 = _extract_mac(b"", 1, "shortsn")
+        assert mac3 is None
+
     async def test_discover(self) -> None:
         """Test discover."""
         mock_device = {
@@ -111,7 +130,8 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             "ip_address": "192.168.0.2",
             "port": 6444,
             "model": "AC123000",
-            "sn": "0000AC12300000000000000000000000",
+            "sn": "0000AC12300000001234567890ABCDEF",
+            "mac": "1234567890AB",
         }
         mock_cloud_instance = AsyncMock()
         mock_device_instance = MagicMock()

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -46,6 +46,7 @@ class MideaDeviceTest:
             model="test_model",
             subtype=1,
             attributes={},
+            mac="1234567890ab",
         )
 
     def test_initial_attributes(self) -> None:
@@ -365,3 +366,9 @@ class MideaDeviceTest:
             self.device.set_ip_address("10.0.0.1")
             socket_mock.close.assert_called()
             assert self.device._ip_address == "10.0.0.1"
+
+    def test_set_mac(self) -> None:
+        """Test set mac."""
+        assert self.device._mac == "1234567890ab"
+        self.device.set_mac("9234567890ab")
+        assert self.device._mac == "9234567890ab"


### PR DESCRIPTION
This PR extracts the MAC address from the discover process and provides the attribute `.mac` to the device class, so https://github.com/wuwentao/midea_ac_lan/pull/868 can work