### PR TITLE
refactor: use kwargs in device subclasses

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections.abc import Callable
 from enum import IntEnum, StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict, Unpack
 
 from typing_extensions import deprecated
 
@@ -64,39 +64,53 @@ class MessageResult(IntEnum):
     ERROR = 99
 
 
+class MideaDeviceInitKwargs(TypedDict):
+    """Connection/identity kwargs forwarded by device subclasses to MideaDevice.
+
+    Every device subclass's ``__init__`` accepts these via ``**kwargs`` and
+    forwards them unchanged to ``MideaDevice.__init__``. Keeping them in one
+    place means adding a field here (e.g. ``mac``, ``serial_number``) is
+    enough for every subclass to accept and forward it, with no per-subclass
+    signature changes required.
+    """
+
+    name: str
+    device_id: int
+    ip_address: str
+    port: int
+    token: str
+    key: str
+    device_protocol: ProtocolVersion
+    model: str
+    subtype: int
+
+
 class MideaDevice(threading.Thread):
     """Midea device."""
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
+        *,
         device_type: DeviceType,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
         attributes: dict,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Midea device initialization."""
         threading.Thread.__init__(self)
         self._attributes = attributes or {}
         self._socket: socket.socket | None = None
-        self._ip_address = ip_address
-        self._port = port
+        self._ip_address = kwargs["ip_address"]
+        self._port = kwargs["port"]
         self._security = LocalSecurity()
-        self._token = bytes.fromhex(token)
-        self._key = bytes.fromhex(key)
+        self._token = bytes.fromhex(kwargs["token"])
+        self._key = bytes.fromhex(kwargs["key"])
         self._buffer = b""
-        self._device_name = name
-        self._device_id = device_id
+        self._device_name = kwargs["name"]
+        self._device_id = kwargs["device_id"]
         self._device_type = device_type
-        self._device_protocol_version = device_protocol
-        self._model = model
-        self._subtype = subtype
+        self._device_protocol_version = kwargs["device_protocol"]
+        self._model = kwargs["model"]
+        self._subtype = kwargs["subtype"]
         self._message_protocol_version: int = 0
         self._updates: list[Callable[[dict[str, Any]], None]] = []
         self._unsupported_protocol: list[str] = []

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageA1Response, MessageQuery, MessageSet
 
@@ -55,29 +55,14 @@ class MideaA1Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea A1 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.A1,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.prompt_tone: True,

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageACResponse,
@@ -114,29 +114,14 @@ class MideaACDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea AC device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.AC,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.prompt_tone: True,
                 DeviceAttributes.power: False,

--- a/midealocal/devices/ad/__init__.py
+++ b/midealocal/devices/ad/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import Message21Query, Message31Query, MessageADResponse
 
@@ -45,29 +45,14 @@ class MideaADDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea AD device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.AD,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.temperature: None,
                 DeviceAttributes.humidity: None,

--- a/midealocal/devices/b0/__init__.py
+++ b/midealocal/devices/b0/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import ClassVar
+from typing import ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageB0Response,
@@ -155,29 +155,14 @@ class MideaB0Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize B0 Midea device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B0,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.door: False,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/b1/__init__.py
+++ b/midealocal/devices/b1/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageB1Response, MessageQuery
 
@@ -38,29 +38,14 @@ class MideaB1Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea B1 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B1,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.door: False,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/b3/__init__.py
+++ b/midealocal/devices/b3/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageB3Response, MessageQuery
 
@@ -52,29 +52,14 @@ class MideaB3Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea local B3 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B3,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.top_compartment_status: None,
                 DeviceAttributes.top_compartment_mode: None,

--- a/midealocal/devices/b4/__init__.py
+++ b/midealocal/devices/b4/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageB4Response, MessageQuery
 
@@ -38,29 +38,14 @@ class MideaB4Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea B4 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B4,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.door: False,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/b6/__init__.py
+++ b/midealocal/devices/b6/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageB6Response, MessageQuery, MessageSet
 
@@ -30,29 +30,14 @@ class MideaB6Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea B6 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B6,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.light: None,

--- a/midealocal/devices/b8/__init__.py
+++ b/midealocal/devices/b8/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import IntEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .const import (
     B8CleanMode,
@@ -37,29 +37,14 @@ class MideaB8Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea B8 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.B8,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 B8DeviceAttributes.WORK_STATUS: B8WorkStatus.NONE.name.lower(),
                 B8DeviceAttributes.FUNCTION_TYPE: B8FunctionType.NONE.name.lower(),

--- a/midealocal/devices/bf/__init__.py
+++ b/midealocal/devices/bf/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageBFResponse, MessageQuery
 
@@ -38,29 +38,14 @@ class MideaBFDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea BF device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.BF,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.door: None,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/c2/__init__.py
+++ b/midealocal/devices/c2/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageC2Response, MessagePower, MessageQuery, MessageSet
 
@@ -36,29 +36,14 @@ class MideaC2Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea C2 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.C2,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.child_lock: False,

--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -2,10 +2,10 @@
 
 import json
 import logging
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .const import C3DeviceMode, C3SilentLevel, DeviceAttributes
 from .message import (
@@ -36,29 +36,14 @@ class MideaC3Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea C3 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.C3,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.zone1_power: False,
                 DeviceAttributes.zone2_power: False,

--- a/midealocal/devices/ca/__init__.py
+++ b/midealocal/devices/ca/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageCAResponse, MessageQuery
 
@@ -61,29 +61,14 @@ class MideaCADevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea CA device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.CA,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.energy_consumption: None,
                 DeviceAttributes.refrigerator_actual_temp: None,

--- a/midealocal/devices/cc/__init__.py
+++ b/midealocal/devices/cc/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     INDEX_TO_FE_MODE,
@@ -73,29 +73,14 @@ class MideaCCDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea CC device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.CC,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: 1,

--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import IntEnum, StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageCDBase,
@@ -105,29 +105,14 @@ class MideaCDDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea CD device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.CD,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: None,

--- a/midealocal/devices/ce/__init__.py
+++ b/midealocal/devices/ce/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageCEResponse, MessageQuery, MessageSet
 
@@ -43,29 +43,14 @@ class MideaCEDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea CE device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.CE,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: None,

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import MessageCFResponse, MessageQuery, MessageSet
@@ -32,29 +32,14 @@ class MideaCFDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea CF device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.CF,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: 0,

--- a/midealocal/devices/da/__init__.py
+++ b/midealocal/devices/da/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import MessageDAResponse, MessagePower, MessageQuery, MessageStart
@@ -42,29 +42,14 @@ class MideaDADevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea DA device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.DA,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.start: False,

--- a/midealocal/devices/db/__init__.py
+++ b/midealocal/devices/db/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import MessageDBResponse, MessagePower, MessageQuery, MessageStart
@@ -196,29 +196,14 @@ class MideaDBDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea DB device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.DB,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.start: False,

--- a/midealocal/devices/dc/__init__.py
+++ b/midealocal/devices/dc/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import MessageDCResponse, MessagePower, MessageQuery, MessageStart
@@ -104,29 +104,14 @@ class MideaDCDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea DC device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.DC,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.start: False,

--- a/midealocal/devices/e1/__init__.py
+++ b/midealocal/devices/e1/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import (
@@ -53,29 +53,14 @@ class MideaE1Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea E1 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.E1,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -4,10 +4,10 @@ import json
 import logging
 import math
 from enum import IntEnum, StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageE2Response,
@@ -88,29 +88,14 @@ class MideaE2Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea E2 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.E2,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.heating: False,

--- a/midealocal/devices/e3/__init__.py
+++ b/midealocal/devices/e3/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import (
     MessageE3Response,
@@ -37,29 +37,14 @@ class MideaE3Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea E3 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.E3,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.burning_state: False,

--- a/midealocal/devices/e6/__init__.py
+++ b/midealocal/devices/e6/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageE6Response, MessageQuery, MessageSet
 
@@ -43,29 +43,14 @@ class MideaE6Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea E6 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.E6,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.main_power: False,
                 DeviceAttributes.heating_power: True,

--- a/midealocal/devices/e8/__init__.py
+++ b/midealocal/devices/e8/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageE8Response, MessageQuery
 
@@ -39,29 +39,14 @@ class MideaE8Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea E8 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.E8,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.status: None,
                 DeviceAttributes.time_remaining: None,

--- a/midealocal/devices/ea/__init__.py
+++ b/midealocal/devices/ea/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageEAResponse, MessageQuery
 
@@ -134,29 +134,14 @@ class MideaEADevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea EA device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.EA,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.cooking: False,
                 DeviceAttributes.keep_warm: False,

--- a/midealocal/devices/ec/__init__.py
+++ b/midealocal/devices/ec/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageECResponse, MessageQuery
 
@@ -146,29 +146,14 @@ class MideaECDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea EC device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.EC,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.cooking: False,
                 DeviceAttributes.mode: 0,

--- a/midealocal/devices/ed/__init__.py
+++ b/midealocal/devices/ed/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.message import ListTypes
 
 from .message import (
@@ -46,29 +46,14 @@ class MideaEDDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea ED device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.ED,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.water_consumption: None,

--- a/midealocal/devices/fa/__init__.py
+++ b/midealocal/devices/fa/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageFAResponse, MessageQuery, MessageSet
 
@@ -77,29 +77,14 @@ class MideaFADevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea FA device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.FA,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.child_lock: False,

--- a/midealocal/devices/fb/__init__.py
+++ b/midealocal/devices/fb/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageFBResponse, MessageQuery, MessageSet
 
@@ -40,29 +40,14 @@ class MideaFBDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea FB device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.FB,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: None,

--- a/midealocal/devices/fc/__init__.py
+++ b/midealocal/devices/fc/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageFCResponse, MessageQuery, MessageSet
 
@@ -57,29 +57,14 @@ class MideaFCDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea FC device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.FC,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.mode: None,

--- a/midealocal/devices/fd/__init__.py
+++ b/midealocal/devices/fd/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageFDResponse, MessageQuery, MessageSet
 
@@ -62,29 +62,14 @@ class MideaFDDevice(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea FD device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.FD,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.fan_speed: None,

--- a/midealocal/devices/x13/__init__.py
+++ b/midealocal/devices/x13/__init__.py
@@ -3,10 +3,10 @@
 import json
 import logging
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import Message13Response, MessageQuery, MessageSet
 
@@ -37,29 +37,14 @@ class Midea13Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea x13 Device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.X13,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.brightness: None,
                 DeviceAttributes.color_temperature: None,

--- a/midealocal/devices/x26/__init__.py
+++ b/midealocal/devices/x26/__init__.py
@@ -3,10 +3,10 @@
 import logging
 import math
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import Message26Response, MessageQuery, MessageSet
 
@@ -53,29 +53,14 @@ class Midea26Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea x26 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.X26,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.main_light: False,
                 DeviceAttributes.night_light: False,

--- a/midealocal/devices/x34/__init__.py
+++ b/midealocal/devices/x34/__init__.py
@@ -2,10 +2,10 @@
 
 import logging
 from enum import StrEnum
-from typing import Any
+from typing import Any, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.exceptions import ValueWrongType
 
 from .message import (
@@ -53,29 +53,14 @@ class Midea34Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,  # noqa: ARG002
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea x34 device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.X34,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.power: False,
                 DeviceAttributes.status: None,

--- a/midealocal/devices/x40/__init__.py
+++ b/midealocal/devices/x40/__init__.py
@@ -4,10 +4,10 @@ import json
 import logging
 import math
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
-from midealocal.const import DeviceType, ProtocolVersion
-from midealocal.device import MideaDevice
+from midealocal.const import DeviceType
+from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
 from .message import MessageQuery, MessageSet, MessageX40Response
 
@@ -36,29 +36,14 @@ class MideaX40Device(MideaDevice):
 
     def __init__(
         self,
-        name: str,
-        device_id: int,
-        ip_address: str,
-        port: int,
-        token: str,
-        key: str,
-        device_protocol: ProtocolVersion,
-        model: str,
-        subtype: int,
+        *,
         customize: str,
+        **kwargs: Unpack[MideaDeviceInitKwargs],
     ) -> None:
         """Initialize Midea x40 Device."""
         super().__init__(
-            name=name,
-            device_id=device_id,
             device_type=DeviceType.X40,
-            ip_address=ip_address,
-            port=port,
-            token=token,
-            key=key,
-            device_protocol=device_protocol,
-            model=model,
-            subtype=subtype,
+            **kwargs,
             attributes={
                 DeviceAttributes.light: False,
                 DeviceAttributes.fan_speed: 0,


### PR DESCRIPTION
If we add an argument to the base device class we
do not want to edit the +30 device subclasses.

This is related to #488, to remove boilerplate code and reduce the size of that PR