### PR TITLE
refactor(cli): drop redundant V3 authenticate() in discover()

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -124,9 +124,8 @@ class MideaCLI:
                 _LOGGER.debug("Opening socket for device.")
                 if dev.connect():
                     try:
-                        if device["protocol"] == ProtocolVersion.V3:
-                            _LOGGER.debug("Trying to connect with key: %s", key)
-                            dev.authenticate()
+                        # connect() already authenticates V3 devices, so there
+                        # is no need to call authenticate() again here.
                         _LOGGER.debug("Trying to retrieve device attributes.")
                         dev.refresh_status(True)
                     except AuthException:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -131,13 +131,7 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             ),
             patch.object(
                 mock_device_instance,
-                "authenticate",
-                side_effect=[None, None, AuthException, SocketException],
-            ) as authenticate_mock,
-            patch.object(
-                mock_device_instance,
                 "refresh_status",
-                side_effect=[None, None, NoSupportedProtocol, None],
             ) as refresh_status_mock,
         ):
             mock_discover.return_value = {1: mock_device}
@@ -155,22 +149,28 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             # set get_sn to default False after test done
             self.namespace.get_sn = False
 
-            # test V3 device
+            # test V3 device: connect() already authenticated, discover only
+            # calls refresh_status (once per candidate key).
+            refresh_status_mock.side_effect = None
             await self.cli.discover()  # V3 device
-            authenticate_mock.assert_called()
             refresh_status_mock.assert_called_with(True)
-            authenticate_mock.reset_mock()
             refresh_status_mock.reset_mock()
 
-            await self.cli.discover()  # V3 device AuthException
-            refresh_status_mock.assert_not_called()
-            authenticate_mock.assert_called()
-            authenticate_mock.reset_mock()
+            # V3 device where refresh_status raises: each failure is caught and
+            # the device is simply not added to the list.
+            refresh_status_mock.side_effect = [AuthException, NoSupportedProtocol]
+            assert await self.cli.discover() == []
+            refresh_status_mock.reset_mock()
+
+            refresh_status_mock.side_effect = [SocketException, None]
+            await self.cli.discover()  # V3 device SocketException on first key
+            refresh_status_mock.reset_mock()
 
             mock_device["protocol"] = ProtocolVersion.V2
-            await self.cli.discover()  # V2 device NoSupportedProtocol
-            authenticate_mock.assert_not_called()
-            refresh_status_mock.assert_called_once()
+            refresh_status_mock.side_effect = None
+            await self.cli.discover()  # V2 device
+            refresh_status_mock.assert_called_with(True)
+            refresh_status_mock.reset_mock()
 
             mock_device_instance.connect.return_value = False
             await self.cli.discover()  # connect failed


### PR DESCRIPTION
## Summary
Remove the redundant second `authenticate()` call in `MideaCLI.discover()`.

`MideaDevice.connect()` already authenticates V3 devices internally:

```python
# midealocal/device.py
if self._device_protocol_version == ProtocolVersion.V3:
    self.authenticate()
```

So after `dev.connect()` returns `True`, a V3 device is already authenticated. The subsequent `dev.authenticate()` in `discover()` performs a **second handshake** on the just-connected socket for every V3 device — wasted work, and on a device that rejects a repeat handshake it can raise `AuthException` and drop a device that actually connected fine.

## Changes
- `cli.py`: drop the `if protocol == V3: dev.authenticate()` block in `discover()`. `refresh_status(True)` still runs and still surfaces `AuthException` / `SocketException` / `NoSupportedProtocol`, caught exactly as before.
- `tests/cli_test.py`: `test_discover` previously mocked `connect()` (so it relied on the explicit `authenticate()` to exercise the failure paths). Rewired the `AuthException` / `SocketException` / `NoSupportedProtocol` cases to be driven through `refresh_status` (the call that remains), preserving coverage.

## Testing
- `pytest ./tests/` → **242 passed**
- `ruff check` / `ruff format --check` (pinned `v0.6.9`) → clean
- `mypy` → clean

## Context
This is a pre-existing redundancy noticed while reviewing #476 (socket-closure). It was intentionally kept **out** of that PR to keep #476 scoped to the socket-lifecycle changes; splitting it here as a standalone fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
