### PR TITLE
fix(cd): use 25-byte RSJRAC SET body with tsMax (#468)

### DIFF
--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -526,20 +526,29 @@ class MideaCDDevice(MideaDevice):
                 message.vacation_days = days
 
             # persist only safe fields; SET echoes often return openPTC=1 / bad Tr
-            fields = dict(message.fields)
-            for key in ("openPTC", "ptcTemp", "byte8"):
-                fields.pop(key, None)
-            tr = fields.get("trValue")
-            try:
-                tr_i = int(tr) if tr is not None else 0
-            except (TypeError, ValueError):
-                tr_i = 0
-            if tr_i < MessageSet.TR_VALUE_MIN or tr_i > MessageSet.TR_VALUE_MAX:
-                fields.pop("trValue", None)
+            self._fields = self._sanitize_set_fields(message.fields)
             # Avoid replaying SET-echo junk into the next control frame
-            message.fields = {k: v for k, v in fields.items() if k == "trValue"}
-            self._fields = fields
+            message.fields = dict(self._fields)
             self.build_send(message)
+
+    @staticmethod
+    def _sanitize_set_fields(fields: dict[Any, Any]) -> dict[Any, Any]:
+        """Strip SET-echo junk so it is not replayed into the next frame.
+
+        Drops openPTC/ptcTemp/byte8 (openPTC is forced 0 by MessageSet) and
+        removes an out-of-range trValue so only a valid Tr survives.
+        """
+        clean = dict(fields)
+        for key in ("openPTC", "ptcTemp", "byte8"):
+            clean.pop(key, None)
+        tr = clean.get("trValue")
+        try:
+            tr_i = int(tr) if tr is not None else 0
+        except (TypeError, ValueError):
+            tr_i = 0
+        if tr_i < MessageSet.TR_VALUE_MIN or tr_i > MessageSet.TR_VALUE_MAX:
+            clean.pop("trValue", None)
+        return {k: v for k, v in clean.items() if k == "trValue"}
 
     def set_customize(self, customize: str) -> None:
         """Midea CD device set customize."""

--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -415,15 +415,29 @@ class MideaCDDevice(MideaDevice):
                 self._attributes.get(DeviceAttributes.fahrenheit, False),
             )
 
-            # Maximum target temperature echo (bodyBytes[21]); this mirrors
-            # the Lua vacationTsValue byte but is exposed as max_temperature.
-            # max_temperature is the canonical exposed attribute for this value.
-            vac_temp = self._attributes.get(DeviceAttributes.max_temperature)
-            message.max_temperature = (
-                float(vac_temp)
-                if isinstance(vac_temp, int | float) and vac_temp > 0
-                else 0.0
-            )
+            # full[21] vacationTsValue — not max temperature.
+            # full[23] tsMax — must be the device max (issue #468); 0 clamps SP.
+            if attr in (
+                DeviceAttributes.target_temperature,
+                DeviceAttributes.mode,
+                DeviceAttributes.power,
+            ):
+                # Plain control: leave vacationTs at 0 (Lua default).
+                message.vacation_temperature = 0.0
+            else:
+                vac_temp = self._attributes.get(DeviceAttributes.vacation_temperature)
+                message.vacation_temperature = (
+                    float(vac_temp)
+                    if isinstance(vac_temp, int | float) and vac_temp > 0
+                    else 0.0
+                )
+            mx = self._attributes.get(DeviceAttributes.max_temperature)
+            try:
+                message.ts_max = (
+                    int(mx) if isinstance(mx, int | float) and mx > 0 else 0
+                )
+            except (TypeError, ValueError):
+                message.ts_max = 0
 
             # Ensure temperature is valid (not None/0)
             if isinstance(current_temp, int | float) and current_temp > 0:
@@ -511,8 +525,20 @@ class MideaCDDevice(MideaDevice):
                 message.vacation_flag = True
                 message.vacation_days = days
 
-            # persist fields for subsequent calls
-            self._fields = dict(message.fields)
+            # persist only safe fields; SET echoes often return openPTC=1 / bad Tr
+            fields = dict(message.fields)
+            for key in ("openPTC", "ptcTemp", "byte8"):
+                fields.pop(key, None)
+            tr = fields.get("trValue")
+            try:
+                tr_i = int(tr) if tr is not None else 0
+            except (TypeError, ValueError):
+                tr_i = 0
+            if tr_i < MessageSet.TR_VALUE_MIN or tr_i > MessageSet.TR_VALUE_MAX:
+                fields.pop("trValue", None)
+            # Avoid replaying SET-echo junk into the next control frame
+            message.fields = {k: v for k, v in fields.items() if k == "trValue"}
+            self._fields = fields
             self.build_send(message)
 
     def set_customize(self, customize: str) -> None:

--- a/midealocal/devices/cd/message.py
+++ b/midealocal/devices/cd/message.py
@@ -112,26 +112,33 @@ class MessageQueryDaily(MessageCDBase):
 class MessageSet(MessageCDBase):
     """CD message set (controlType=0x01).
 
-    Builds a 22-byte body matching the Lua jsonToData controlType=0x01 layout:
-      bodyBytes[0]     = 0x01 (body_type, prepended by MessageRequest.body)
-      bodyBytes[1]     = 0x01 (constant, _body[0])
-      bodyBytes[2]     = powerValue
-      bodyBytes[3]     = modeValue  (0x01-0x04; vacation is NOT a mode value here)
-      bodyBytes[4]     = tsValue    (target temperature, encoded per protocol)
-      bodyBytes[5]     = trValue
-      bodyBytes[6]     = openPTC
-      bodyBytes[7]     = ptcTemp
-      bodyBytes[8]     = flags: bit 0x10=vacationMode,
-                         bit 0x80=fahrenheit, bit 0x08=mute.
-                         Built from scratch per Lua L5621-5623;
-                         other bits are NOT sent.
-      bodyBytes[9..10] = vacadaysValue high/low (vacation remaining days, big-endian)
-      bodyBytes[11..17]= date/time fields (sent as 0)
-      bodyBytes[18..20]= vacation start year/month/day (sent as 0)
-      bodyBytes[21]    = vacationTsValue (vacation target temperature, raw)
+    RSJRAC07 / extended Lua (T_0000_CD_RSJRAC07) expects a **25-byte** control
+    body (body_type + 24-byte payload). A shorter body faults the unit: target
+    and max temperature become 0 until power-cycled or restored via the app.
+
+    Layout (after MessageRequest prepends body_type at full[0]):
+      full[1]  = 0x01 constant
+      full[2]  = power
+      full[3]  = mode (1 eco, 2 standard, 3 dual/compatibilizing, 4 smart, ...)
+      full[4]  = target temperature (raw °C for new protocol)
+      full[5]  = trValue (hysteresis; Lua range 2-6)
+      full[6]  = openPTC (Lua forces 0 on normal sets)
+      full[7]  = ptcTemp
+      full[8]  = flags (vacation 0x10 / °F 0x80 / mute 0x08)
+      full[9..20] = vacation days + date fields (0 for a plain set)
+      full[21] = vacationTsValue
+      full[22] = timer_type
+      full[23] = **tsMax** (device max temperature; must not be 0)
+      full[24] = dr_switch
+
+    See https://github.com/midea-lan/midea-local/issues/468
     """
 
     DEFAULT_VACATION_DAYS = 100
+    TR_VALUE_MIN = 2
+    TR_VALUE_MAX = 6
+    DEFAULT_TR_VALUE = 5
+    DEFAULT_TS_MAX = 65
 
     def __init__(self, protocol_version: int) -> None:
         """Initialize CD message set."""
@@ -153,59 +160,90 @@ class MessageSet(MessageCDBase):
         self.vacation_days: int = 0
         # fahrenheit mode (bit 0x80 in bodyBytes[8])
         self.fahrenheit: bool = False
-        # maximum target temperature (bodyBytes[21], raw device value)
-        self.max_temperature: float = 0
+        # vacation target temperature (full[21] / vacationTsValue)
+        self.vacation_temperature: float = 0
+        # device max temperature limit (full[23] / tsMax) — must be non-zero
+        self.ts_max: int = 0
 
     def read_field(self, field: str) -> int:
         """CD message set read field."""
         value = self.fields.get(field, 0)
         return int(value) if value else 0
 
+    def _tr_value(self) -> int:
+        """Return Tr hysteresis in the Lua-documented [2, 6] range."""
+        tr = self.read_field("trValue")
+        if tr < self.TR_VALUE_MIN or tr > self.TR_VALUE_MAX:
+            return self.DEFAULT_TR_VALUE
+        return tr
+
+    def _ts_max_value(self) -> int:
+        """Return tsMax; never 0 (firmware clamps setpoint when tsMax is 0)."""
+        try:
+            value = int(self.ts_max)
+        except (TypeError, ValueError):
+            value = 0
+        if value <= 0:
+            return self.DEFAULT_TS_MAX
+        return value & 0xFF
+
     @property
     def _body(self) -> bytearray:
         power = 0x01 if self.power else 0x00
-        mode = self.mode
-        # new protocol sends raw value, old protocol doubles and adds offset
+        mode = int(self.mode) & 0xFF
         target_temperature = (
             round(self.target_temperature * 2 + 30)
             if self.use_old_protocol
             else round(self.target_temperature)
         )
-        # Build byte8 from scratch per Lua L5621-5623:
-        #   only vacationMode (0x10), fahrenheitEffect (0x80), mute (0x08)
-        # All other bits (waterPump, defrost, openPTCTemp, etc.) are NOT sent,
-        # matching the Lua app behaviour which also leaves them out.
+        # flags: vacation / fahrenheit only (Lua normal set; openPTC forced 0)
         byte8 = 0
         if self.vacation_flag:
             byte8 |= 0x10
         if self.fahrenheit:
             byte8 |= 0x80
-        byte8 |= self.read_field("byte8") & 0x08  # preserve mute bit only
-        vacation_high = (self.vacation_days >> 8) & 0xFF
-        vacation_low = self.vacation_days & 0xFF
+
+        if self.vacation_flag or self.vacation_days:
+            vacation_high = (int(self.vacation_days) >> 8) & 0xFF
+            vacation_low = int(self.vacation_days) & 0xFF
+        else:
+            vacation_high = 0
+            vacation_low = 0
+
+        vacation_ts = 0
+        if (
+            isinstance(self.vacation_temperature, int | float)
+            and self.vacation_temperature > 0
+        ):
+            vacation_ts = int(self.vacation_temperature) & 0xFF
+
+        # 24-byte payload; MessageRequest prepends body_type → 25-byte body
         return bytearray(
             [
-                0x01,  # bodyBytes[1] constant
-                power,  # bodyBytes[2] powerValue
-                mode,  # bodyBytes[3] modeValue (0x01-0x04)
-                int(target_temperature),  # bodyBytes[4] tsValue
-                self.read_field("trValue"),  # bodyBytes[5]
-                self.read_field("openPTC"),  # bodyBytes[6]
-                self.read_field("ptcTemp"),  # bodyBytes[7]
-                byte8,  # bodyBytes[8] flags (vacation|fahrenheit|mute only)
-                vacation_high,  # bodyBytes[9] vacadaysValue high
-                vacation_low,  # bodyBytes[10] vacadaysValue low
-                0,  # bodyBytes[11] dateYearValue high
-                0,  # bodyBytes[12] dateYearValue low
-                0,  # bodyBytes[13] dateMonthValue
-                0,  # bodyBytes[14] dateDayValue
-                0,  # bodyBytes[15] dateWeekValue
-                0,  # bodyBytes[16] dateHourValue
-                0,  # bodyBytes[17] dateMinuteValue
-                0,  # bodyBytes[18] vacadaysStartYearValue
-                0,  # bodyBytes[19] vacadaysStartMonthValue
-                0,  # bodyBytes[20] vacadaysStartDayValue
-                int(self.max_temperature),  # bodyBytes[21] max_temperature
+                0x01,  # full[1] constant
+                power,  # full[2]
+                mode,  # full[3]
+                int(target_temperature) & 0xFF,  # full[4]
+                self._tr_value() & 0xFF,  # full[5]
+                0x00,  # full[6] openPTC forced 0 (Lua normal set)
+                self.read_field("ptcTemp") & 0xFF,  # full[7]
+                byte8 & 0xFF,  # full[8]
+                vacation_high,  # full[9]
+                vacation_low,  # full[10]
+                0,  # full[11]
+                0,  # full[12]
+                0,  # full[13]
+                0,  # full[14]
+                0,  # full[15]
+                0,  # full[16]
+                0,  # full[17]
+                0,  # full[18]
+                0,  # full[19]
+                0,  # full[20]
+                vacation_ts,  # full[21] vacationTsValue
+                0x00,  # full[22] timer_type
+                self._ts_max_value(),  # full[23] tsMax (must be non-zero)
+                0x00,  # full[24] dr_switch
             ],
         )
 

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -61,8 +61,7 @@ class TestMideaCDDevice:
 
     def test_set_target_temperature_body_length_and_ts_max(self) -> None:
         """set_temperature builds 25-byte body with non-zero tsMax."""
-        # RSJRAC07 uses new (raw °C) Lua protocol — matches issue #468 device.
-        self.device.model = "RSJRAC07"
+        # RSJRAC07 uses the new (raw °C) Lua protocol — matches issue #468.
         self.device.set_customize('{"lua_protocol": "new"}')
         self.device._attributes[DeviceAttributes.max_temperature] = 65.0
         self.device._attributes[DeviceAttributes.target_temperature] = 60.0

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -30,7 +30,7 @@ class TestMideaCDDevice:
         )
 
     # ------------------------------------------------------------------ #
-    # max_temperature echo for bodyBytes[21]                              #
+    # MessageSet 25-byte body / tsMax (issue #468)                        #
     # ------------------------------------------------------------------ #
 
     def test_preset_modes_excludes_vacation_from_selectable_modes(self) -> None:
@@ -44,18 +44,43 @@ class TestMideaCDDevice:
             self.device.set_attribute(DeviceAttributes.mode.value, "Vacation")
             mock_send.assert_not_called()
 
-    def test_set_power_uses_max_temperature_for_body_21_echo(self) -> None:
-        """SET message uses max_temperature as the internal body[21] echo."""
-        self.device._attributes[DeviceAttributes.max_temperature] = 65.0
+    def test_set_power_uses_ts_max_at_body_23(self) -> None:
+        """Plain SET uses device max_temperature as full[23] tsMax (#468)."""
+        self.device._attributes[DeviceAttributes.max_temperature] = 70.0
+        self.device._attributes[DeviceAttributes.vacation_temperature] = 65.0
 
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
-            assert msg.max_temperature == 65.0
+            assert msg.ts_max == 70
+            assert len(msg.body) == 25
+            assert msg.body[23] == 70  # tsMax
+            assert msg.body[21] == 0  # vacationTs left 0 on plain set
+            assert msg.body[4] != 0  # target present
 
-    def test_disable_vacation_uses_max_temperature_fallback(self) -> None:
-        """Disabling vacation sends max_temperature as the internal body[21] echo."""
+    def test_set_target_temperature_body_length_and_ts_max(self) -> None:
+        """set_temperature builds 25-byte body with non-zero tsMax."""
+        # RSJRAC07 uses new (raw °C) Lua protocol — matches issue #468 device.
+        self.device.model = "RSJRAC07"
+        self.device.set_customize('{"lua_protocol": "new"}')
+        self.device._attributes[DeviceAttributes.max_temperature] = 65.0
+        self.device._attributes[DeviceAttributes.target_temperature] = 60.0
+        self.device._attributes[DeviceAttributes.power] = True
+        self.device._attributes[DeviceAttributes.mode] = "Standard"
+
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(DeviceAttributes.target_temperature.value, 63.0)
+            mock_send.assert_called_once()
+            msg = mock_send.call_args[0][0]
+            assert msg.target_temperature == 63.0
+            assert msg.use_old_protocol is False
+            assert len(msg.body) == 25
+            assert msg.body[4] == 63
+            assert msg.body[23] == 65
+
+    def test_disable_vacation_sets_flag_and_mode(self) -> None:
+        """Disabling vacation clears flag and forces Energy-save mode."""
         self.device._attributes[DeviceAttributes.max_temperature] = 65.0
         self.device._attributes[DeviceAttributes.vacation_mode] = True
 
@@ -63,31 +88,33 @@ class TestMideaCDDevice:
             self.device.set_attribute(DeviceAttributes.vacation_mode.value, False)
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
-            assert msg.max_temperature == 65.0
             assert msg.vacation_flag is False
             assert msg.vacation_days == 0
+            assert msg.mode == 0x01
+            assert msg.body[23] == 65
 
-    def test_set_vacation_days_uses_max_temperature_fallback(self) -> None:
-        """Setting vacation_days sends max_temperature as the internal body[21] echo."""
+    def test_set_vacation_days_encodes_days(self) -> None:
+        """vacation_days SET keeps tsMax and marks vacation flag."""
         self.device._attributes[DeviceAttributes.max_temperature] = 65.0
 
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.vacation_days.value, 30)
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
-            assert msg.max_temperature == 65.0
             assert msg.vacation_flag is True
             assert msg.vacation_days == 30
+            assert msg.body[10] == 30  # vacation days low
+            assert msg.body[23] == 65
 
-    def test_max_temperature_fallback_zero_when_absent(self) -> None:
-        """max_temperature=None gives internal body[21] echo 0.0."""
+    def test_ts_max_falls_back_when_max_missing(self) -> None:
+        """Missing max_temperature still yields non-zero tsMax via MessageSet."""
         self.device._attributes[DeviceAttributes.max_temperature] = None
 
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
-            assert msg.max_temperature == 0.0
+            assert msg.body[23] != 0
 
     # ------------------------------------------------------------------ #
     # disinfect set_attribute                                              #

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -348,3 +348,81 @@ class TestMessageSetSterilize:
         assert msg.body[3] == 4
         msg.disinfection_temperature = None
         assert msg.body[3] == 4  # week restored
+
+
+class TestMessageSetRsjracBody:
+    """Regression tests for CD controlType=0x01 25-byte SET body (#468)."""
+
+    def test_body_length_is_25_with_type(self) -> None:
+        """MessageSet.body is body_type + 24-byte payload."""
+        from midealocal.devices.cd.message import MessageSet
+
+        msg = MessageSet(protocol_version=8)
+        msg.power = True
+        msg.mode = 0x02
+        msg.target_temperature = 63
+        msg.use_old_protocol = False
+        msg.ts_max = 65
+        body = msg.body
+        assert len(body) == 25
+        assert body[0] == 0x01
+        assert body[4] == 63
+        assert body[23] == 65
+        assert body[24] == 0
+
+    def test_ts_max_zero_falls_back(self) -> None:
+        """tsMax must never be emitted as 0."""
+        from midealocal.devices.cd.message import MessageSet
+
+        msg = MessageSet(protocol_version=8)
+        msg.power = True
+        msg.mode = 0x01
+        msg.target_temperature = 60
+        msg.use_old_protocol = False
+        msg.ts_max = 0
+        assert msg.body[23] == MessageSet.DEFAULT_TS_MAX
+
+    def test_tr_clamped(self) -> None:
+        """Out-of-range Tr is clamped to default 5."""
+        from midealocal.devices.cd.message import MessageSet
+
+        msg = MessageSet(protocol_version=8)
+        msg.power = True
+        msg.mode = 0x01
+        msg.target_temperature = 60
+        msg.use_old_protocol = False
+        msg.ts_max = 65
+        msg.fields = {"trValue": 13}
+        assert msg.body[5] == 5
+
+    def test_open_ptc_forced_zero(self) -> None:
+        """Normal sets force openPTC=0 even if fields claim otherwise."""
+        from midealocal.devices.cd.message import MessageSet
+
+        msg = MessageSet(protocol_version=8)
+        msg.power = True
+        msg.mode = 0x02
+        msg.target_temperature = 63
+        msg.use_old_protocol = False
+        msg.ts_max = 65
+        msg.fields = {"openPTC": 1, "trValue": 5}
+        assert msg.body[6] == 0
+
+    def test_vacation_days_in_body(self) -> None:
+        """Vacation SET encodes days in full[9..10]."""
+        from midealocal.devices.cd.message import MessageSet
+
+        msg = MessageSet(protocol_version=8)
+        msg.power = True
+        msg.mode = 0x01
+        msg.target_temperature = 50
+        msg.use_old_protocol = False
+        msg.ts_max = 65
+        msg.vacation_flag = True
+        msg.vacation_days = 30
+        msg.vacation_temperature = 50
+        body = msg.body
+        assert body[9] == 0
+        assert body[10] == 30
+        assert body[21] == 50
+        assert body[23] == 65

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -3,6 +3,7 @@
 from midealocal.devices.cd.message import (
     CDGeneralMessageBody,
     CDSterilizeSetBody,
+    MessageSet,
     MessageSetSterilize,
 )
 
@@ -355,8 +356,6 @@ class TestMessageSetRsjracBody:
 
     def test_body_length_is_25_with_type(self) -> None:
         """MessageSet.body is body_type + 24-byte payload."""
-        from midealocal.devices.cd.message import MessageSet
-
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x02
@@ -371,9 +370,7 @@ class TestMessageSetRsjracBody:
         assert body[24] == 0
 
     def test_ts_max_zero_falls_back(self) -> None:
-        """tsMax must never be emitted as 0."""
-        from midealocal.devices.cd.message import MessageSet
-
+        """Zero tsMax falls back to the default (never emitted as 0)."""
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x01
@@ -384,8 +381,6 @@ class TestMessageSetRsjracBody:
 
     def test_tr_clamped(self) -> None:
         """Out-of-range Tr is clamped to default 5."""
-        from midealocal.devices.cd.message import MessageSet
-
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x01
@@ -397,8 +392,6 @@ class TestMessageSetRsjracBody:
 
     def test_open_ptc_forced_zero(self) -> None:
         """Normal sets force openPTC=0 even if fields claim otherwise."""
-        from midealocal.devices.cd.message import MessageSet
-
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x02
@@ -410,8 +403,6 @@ class TestMessageSetRsjracBody:
 
     def test_vacation_days_in_body(self) -> None:
         """Vacation SET encodes days in full[9..10]."""
-        from midealocal.devices.cd.message import MessageSet
-
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x01


### PR DESCRIPTION
## Summary

Fixes CD (heat-pump water heater) `controlType=0x01` SET frames so they no longer corrupt target/max temperature on **RSJRAC07** and related firmwares.

Closes / related: **#468**

### Problem

Stock `MessageSet` built a **22-byte** body ending at `body[21]`. RSJRAC07 firmware (Lua `T_0000_CD_RSJRAC07`) expects a **25-byte** control body. A short SET:

- zeros or clamps **target temperature** to 0 °C
- corrupts **max water temperature**
- can leave the unit stuck until power-cycle or restore via the official app

Symptom matches reports in #468 (and related integration issues such as wuwentao/midea_ac_lan#515).

### Root cause (from #468)

Official Lua `jsonToData` for `controlType == 0x01` defines:

| full idx | field | notes |
|---|---|---|
| 0 | body_type `0x01` | prepended by `MessageRequest` |
| 1 | constant `0x01` | |
| 2 | power | |
| 3 | mode | |
| 4 | target | raw °C (new protocol) |
| 5 | trValue | hysteresis [2, 6] |
| 6 | openPTC | Lua forces **0** on normal sets |
| 7 | ptcTemp | |
| 8 | flags | vacation / °F / mute |
| 9–20 | vacation/date | 0 for plain set |
| 21 | vacationTs | |
| 22 | timer_type | |
| 23 | **tsMax** | **must not be 0** (0 clamps setpoint) |
| 24 | dr_switch | |

Critical: **body length** and **non-zero `tsMax` at full[23]**. Putting max at full[21] (vacationTs) is wrong.

### Fix

- Extend `MessageSet._body` to **24-byte payload** (25 with body_type)
- Add `ts_max` from device `max_temperature`; fall back to `DEFAULT_TS_MAX` (65) if missing so we never emit 0
- Force `openPTC = 0` on normal sets (Lua)
- Clamp Tr into Lua range [2, 6]
- Plain power/mode/temperature sets leave `vacationTs = 0`; vacation paths still send vacation temperature/days
- Do not replay polluted SET-echo fields (`openPTC` / bad `trValue`) into the next frame

### Verification

Live HA → LAN (device **RSJRAC07**, protocol 3 / message protocol 8):

1. Set target to **63 °C** twice
2. SET echo shows target **63**, subsequent notify keeps **max 65**
3. Official app shows correct target/max (no 0 °C fault)

Unit tests cover body length, `tsMax` placement, Tr clamp, openPTC force-0, and vacation day encoding.

### Notes / risk

- Layout follows RSJRAC07 Lua; older CD subtypes with the short body may need gating if regressions appear
- After release, `midea_ac_lan` only needs a `midea-local` pin bump (no HA platform change)

## Test plan

- [x] Live set target 63 °C ×2 on RSJRAC07 via HA (`midea_ac_lan`)
- [x] Confirm app target/max stay non-zero
- [x] Unit tests for `MessageSet` 25-byte body + device `set_attribute` paths
- [ ] CI pytest on PR
