### PR TITLE
fix: parse temperatures from 0x7E new-protocol tag for AC subtype 8

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -961,6 +961,19 @@ class XBXMessageBody(NewProtocolMessageBody):
                 len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
                 and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
             )
+        # AC subtype 8 (e.g. model 22013279) reports temperatures in the
+        # 0x7e new-protocol tag; the standard C0 frame is stale for it.
+        # https://github.com/wuwentao/midea_ac_lan  (synced-sample analysis)
+        if 0x7E in params:
+            _t = params[0x7E]
+            if len(_t) > 41:
+                self.target_temperature = (_t[3] - 50) / 2
+                self.indoor_temperature = round(
+                    (_t[40] - 50) / 2 + _t[41] * 0.1, 1
+                )
+                # outdoor not available locally on this model (app shows
+                # a cloud/weather value); avoid the bogus C0-derived value
+                self.outdoor_temperature = None
 
 
 class XB5MessageBody(NewProtocolMessageBody):


### PR DESCRIPTION
### Problem
For AC `model 22013279, subtype 8` (device protocol 3, message protocol 0),
all temperatures are wrong (e.g. indoor 2.0, outdoor -9.1 while the Midea app
shows ~26 / 33). The standard C0 frame is a **stale/zombie frame** for this
model (byte-identical across time while real temps change), and the real values
are carried in a `0x7e` new-protocol tag that is currently dropped as
"Unidentified protocol".

### Fix
Parse the `0x7e` tag in `XBXMessageBody`:
- setpoint  = `(data[3] - 50) / 2`
- indoor    = `(data[40] - 50) / 2 + data[41] * 0.1`
- outdoor   = `None` (not available locally on this model; the app value
  appears to be a cloud/weather number)

### Evidence (time-synced raw frame + app values)
| time | 0x7e[3] | 0x7e[40] | 0x7e[41] | app set | app indoor |
|------|---------|----------|----------|---------|------------|
| A | 102 | 100 | 5 | 26 | 25.5 |
| B | 102 | 102 | 6 | 26 | 26.6 |

Sample 0x7e frame:
`b1017e000037a01d41667f7f0000000400000000000000010078004c00c0000000006400640000000000000400006606...`
Sample (stale) C0 frame:
`c00140667f7f000000040034200e001a000000000000000058020000e3ff...`

### Notes / questions for maintainers
- Only affects devices that emit the `0x7e` tag (others are untouched).
- The change is not scoped by `subtype` because `XBXMessageBody` doesn't see it.
  If other models legitimately send `0x7e` for a different purpose, this may need
  a subtype/capability guard — happy to adjust.
- Outdoor is intentionally set to `None`; couldn't map it to any stable byte
  across multiple B5 frames.

<img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/dad0e2f2-f7d1-496c-9beb-5d416667a64a" />
<img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/043e0fdd-6293-4e84-9eb8-81bd94479941" />