### PR TITLE
fix(ac): decode subtype-8 0x7e setpoint and ignore stale C0 temperatures

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Unpack
 
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs
+from midealocal.message import ListTypes
 
 from .message import (
     MessageACResponse,
@@ -82,6 +83,13 @@ class DeviceAttributes(StrEnum):
     self_clean = "self_clean"
     pmv = "pmv"
     error_code = "error_code"
+
+
+STALE_C0_TEMPERATURE_ATTRIBUTES = (
+    DeviceAttributes.target_temperature,
+    DeviceAttributes.indoor_temperature,
+    DeviceAttributes.outdoor_temperature,
+)
 
 
 class MideaACDevice(MideaDevice):
@@ -200,6 +208,9 @@ class MideaACDevice(MideaDevice):
         self._customize_max_temperature: float | None = None
         self._power_analysis_method: int = 1
         self._default_power_analysis_method: int = 1
+        # Once 0x7e-derived temperatures are seen, ignore stale C0 temperature
+        # fields to avoid brief UI flicker caused by query ordering.
+        self._prefer_new_protocol_temperature: bool = False
         self.set_customize(customize)
 
     @property
@@ -262,6 +273,15 @@ class MideaACDevice(MideaDevice):
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         has_fresh_air = False
+        body_type = getattr(message, "body_type", None)
+
+        if getattr(message, "has_subtype8_temperature", False):
+            self._prefer_new_protocol_temperature = True
+
+        is_stale_c0_temperature = (
+            self._prefer_new_protocol_temperature and body_type == ListTypes.C0
+        )
+
         if hasattr(message, "used_subprotocol"):
             self._used_subprotocol = True
             if hasattr(message, "sn8_flag"):
@@ -270,6 +290,8 @@ class MideaACDevice(MideaDevice):
                 self._bb_timer = message.timer
         for attr in self._attributes:
             if hasattr(message, str(attr)):
+                if is_stale_c0_temperature and attr in STALE_C0_TEMPERATURE_ATTRIBUTES:
+                    continue
                 value = getattr(message, str(attr))
                 if attr == DeviceAttributes.fresh_air_power:
                     has_fresh_air = True

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -42,6 +42,19 @@ XC1_SUBBODY_TYPE_44 = 0x44
 XC1_SUBBODY_TYPE_40 = 0x40
 XC1_SUBBODY_TYPE_45 = 0x45
 
+# AC subtype 8 (e.g. model 22013279) reports temperatures in this
+# new-protocol tag instead of the standard C0 frame.
+SUBTYPE8_TEMPERATURE_TAG = 0x7E
+SUBTYPE8_TEMPERATURE_MIN_LENGTH = 40
+SUBTYPE8_SETPOINT_OFFSET = 11.5
+SUBTYPE8_SETPOINT_MASK = 0x3F
+SUBTYPE8_SETPOINT_HALF_DEGREE_BIT = 0x40
+SUBTYPE8_MIN_VALID_TEMPERATURE = 10
+SUBTYPE8_MAX_VALID_TEMPERATURE = 40
+SUBTYPE8_LEGACY_SETPOINT_BYTE = 3
+SUBTYPE8_INDOOR_TEMPERATURE_BYTE = 39
+SUBTYPE8_INDOOR_TEMPERATURE_DECIMAL_BYTE = 40
+
 # B5 capability value semantics (reverse-engineered; see _parse_capabilities).
 # The raw byte of each capability is not a 0/1 flag; each has its own value set.
 B5_HEAT_MODE_VALUES = frozenset({1, 2, 4, 6, 7, 9, 10, 11, 12, 13})
@@ -964,6 +977,50 @@ class XBXMessageBody(NewProtocolMessageBody):
                 len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
                 and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
             )
+        if SUBTYPE8_TEMPERATURE_TAG in params:
+            self.has_subtype8_temperature = True
+            self._parse_subtype8_temperatures(params[SUBTYPE8_TEMPERATURE_TAG])
+
+    def _parse_subtype8_temperatures(self, data: bytearray) -> None:
+        """Decode setpoint/indoor temperature for AC subtype 8 (model 22013279).
+
+        The standard C0 frame is stale for this subtype; temperatures are
+        reported in this new-protocol tag instead. Synced captures show the
+        setpoint in byte 1:
+        - low 6 bits encode 0.5C steps with a +11.5C offset
+        - bit 0x40 adds an extra +0.5C
+        """
+        if len(data) <= SUBTYPE8_TEMPERATURE_MIN_LENGTH:
+            return
+        raw_setpoint = data[1]
+        target_temperature = (
+            SUBTYPE8_SETPOINT_OFFSET + (raw_setpoint & SUBTYPE8_SETPOINT_MASK) / 2
+        )
+        if raw_setpoint & SUBTYPE8_SETPOINT_HALF_DEGREE_BIT:
+            target_temperature += 0.5
+        if not (
+            SUBTYPE8_MIN_VALID_TEMPERATURE
+            <= target_temperature
+            <= SUBTYPE8_MAX_VALID_TEMPERATURE
+        ):
+            # Fallback for payload variants where the legacy byte-3 mapping
+            # is still active.
+            fallback_target = (data[SUBTYPE8_LEGACY_SETPOINT_BYTE] - 50) / 2
+            if (
+                SUBTYPE8_MIN_VALID_TEMPERATURE
+                <= fallback_target
+                <= SUBTYPE8_MAX_VALID_TEMPERATURE
+            ):
+                target_temperature = fallback_target
+        self.target_temperature = target_temperature
+        self.indoor_temperature = round(
+            (data[SUBTYPE8_INDOOR_TEMPERATURE_BYTE] - 50) / 2
+            + data[SUBTYPE8_INDOOR_TEMPERATURE_DECIMAL_BYTE] * 0.1,
+            1,
+        )
+        # Outdoor temperature isn't available locally on this model (the app
+        # shows a cloud/weather value); avoid the bogus C0-derived value.
+        self.outdoor_temperature = None
 
 
 class XB5MessageBody(NewProtocolMessageBody):

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1,5 +1,6 @@
 """Test AC Device."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +18,7 @@ from midealocal.devices.ac.message import (
     MessageSubProtocolQuery,
     PowerFormats,
 )
+from midealocal.message import ListTypes
 
 
 class TestMideaACDevice:
@@ -264,6 +266,40 @@ class TestMideaACDevice:
             assert message.power
             self.device._used_subprotocol = True
             self.device.set_target_temperature(22.5, 1)
+
+    def test_process_message_ignores_stale_c0_temperatures_after_new_protocol(
+        self,
+    ) -> None:
+        """After 0x7e temperatures are seen, stale C0 temperatures are ignored."""
+        new_protocol_msg = SimpleNamespace(
+            body_type=ListTypes.B5,
+            has_subtype8_temperature=True,
+            power=True,
+            target_temperature=27.0,
+            indoor_temperature=28.8,
+            outdoor_temperature=None,
+        )
+        stale_c0_msg = SimpleNamespace(
+            body_type=ListTypes.C0,
+            power=True,
+            target_temperature=16.0,
+            indoor_temperature=4.2,
+            outdoor_temperature=None,
+        )
+
+        with patch(
+            "midealocal.devices.ac.MessageACResponse",
+            side_effect=[new_protocol_msg, stale_c0_msg],
+        ):
+            first = self.device.process_message(b"")
+            assert first[DeviceAttributes.target_temperature.value] == 27.0
+            assert first[DeviceAttributes.indoor_temperature.value] == 28.8
+
+            second = self.device.process_message(b"")
+            assert DeviceAttributes.target_temperature.value not in second
+            assert DeviceAttributes.indoor_temperature.value not in second
+            assert self.device.attributes[DeviceAttributes.target_temperature] == 27.0
+            assert self.device.attributes[DeviceAttributes.indoor_temperature] == 28.8
 
     def test_power_saving_control(self) -> None:
         """Test power saving control and preset exclusivity."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1037,6 +1037,163 @@ class TestMessageACResponse:
         assert hasattr(response, "sound")
         assert response.sound is False
 
+    def test_message_b5_notify2_0x7e_temperature_parse(self) -> None:
+        """Test 0x7e tag parsing for subtype-8 style setpoint and indoor temp."""
+        self.header[9] = 0x05
+        body = bytearray(62)
+        body[0] = 0xB5
+        body[1] = 0x01
+        body[2] = 0x7E
+        body[3] = 0x00
+        body[4] = 0x38
+
+        # 0x7e payload (56 bytes)
+        payload = bytearray(
+            [
+                0xA0,
+                0x1D,  # (_t[1] & 0x3F)/2 + 11.5 -> 26.0
+                0x41,
+                0x66,
+                0x7F,
+                0x7F,
+                0x00,
+                0x00,
+                0x00,
+                0x04,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x78,
+                0x00,
+                0x4C,
+                0x00,
+                0xC0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x00,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x6A,
+                0x08,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x05,
+                0x00,
+            ],
+        )
+        body[5 : 5 + len(payload)] = payload
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "has_subtype8_temperature")
+        assert response.has_subtype8_temperature is True
+        assert hasattr(response, "target_temperature")
+        assert response.target_temperature == 26.0
+        assert hasattr(response, "indoor_temperature")
+        assert response.indoor_temperature == 28.8
+        assert hasattr(response, "outdoor_temperature")
+        assert response.outdoor_temperature is None
+
+    def test_message_b5_notify2_0x7e_temperature_parse_fallback(self) -> None:
+        """Fallback to legacy byte-3 mapping when byte-1 decoding is out of range."""
+        self.header[9] = 0x05
+        body = bytearray(62)
+        body[0] = 0xB5
+        body[1] = 0x01
+        body[2] = 0x7E
+        body[3] = 0x00
+        body[4] = 0x38
+
+        payload = bytearray(
+            [
+                0xA0,
+                0x7F,  # byte-1 mapping would exceed sane range (>40)
+                0x41,
+                0x64,  # fallback byte-3 mapping -> (100 - 50) / 2 = 25.0
+                0x7F,
+                0x7F,
+                0x00,
+                0x00,
+                0x00,
+                0x04,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x78,
+                0x00,
+                0x4C,
+                0x00,
+                0xC0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x64,
+                0x00,
+                0x64,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x6A,
+                0x08,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x05,
+                0x00,
+            ],
+        )
+        body[5 : 5 + len(payload)] = payload
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "target_temperature")
+        assert response.target_temperature == 25.0
+
 
 class TestMessageNewProtocolSetNewFeatures:
     """Test MessageNewProtocolSet for sound and self_clean."""


### PR DESCRIPTION
## Summary
- Fix AC subtype-8 setpoint decoding from the `0x7e` new-protocol payload.
- Decode target temperature from byte-1 bitfield (observed on real device traces), with a safe fallback to legacy byte-3 mapping for variant payloads.
- Prevent brief UI flicker by ignoring stale C0 temperature fields once B1/B5 new-protocol temperatures are observed.
- Add regression tests for:
  - `0x7e` temperature parsing (primary mapping + fallback path)
  - stale C0 temperature suppression after new-protocol temperature updates

## Why
Some subtype-8 devices were reporting implausible or sticky setpoints (for example, always `26.0`) even when the AC app/device setpoint changed. Trace analysis showed that for this model family, the effective setpoint is encoded in `0x7e` byte-1 rather than relying only on the previous mapping path.

## Validation
- Live device trace verification:
  - setpoint `25.0` is decoded as `25.0`
  - setpoint `26.5` is decoded as `26.5`
- IDE diagnostics: no errors in modified files.
