### PR TITLE
fix(e6): renamed temperature wrong attributes

### DIFF
--- a/midealocal/devices/e6/__init__.py
+++ b/midealocal/devices/e6/__init__.py
@@ -20,8 +20,8 @@ class DeviceAttributes(StrEnum):
     heating_power = "heating_power"
     heating_working = "heating_working"
     bathing_working = "bathing_working"
-    min_temperature = "temperature_min"
-    max_temperature = "temperature_max"
+    temperature_min = "temperature_min"
+    temperature_max = "temperature_max"
     heating_temperature = "heating_temperature"
     bathing_temperature = "bathing_temperature"
     heating_leaving_temperature = "heating_leaving_temperature"
@@ -56,8 +56,8 @@ class MideaE6Device(MideaDevice):
                 DeviceAttributes.heating_power: True,
                 DeviceAttributes.heating_working: None,
                 DeviceAttributes.bathing_working: None,
-                DeviceAttributes.min_temperature: [30.0, 35.0],
-                DeviceAttributes.max_temperature: [80.0, 60.0],
+                DeviceAttributes.temperature_min: [30.0, 35.0],
+                DeviceAttributes.temperature_max: [80.0, 60.0],
                 DeviceAttributes.heating_temperature: 50.0,
                 DeviceAttributes.bathing_temperature: 40.0,
                 DeviceAttributes.heating_leaving_temperature: None,

--- a/midealocal/devices/e6/message.py
+++ b/midealocal/devices/e6/message.py
@@ -110,8 +110,8 @@ class E6GeneralMessageBody(MessageBody):
         self.heating_working = (body[2] & 0x10) > 0
         self.bathing_working = (body[2] & 0x20) > 0
         self.heating_power = (body[4] & 0x01) > 0
-        self.min_temperature = [float(body[16]), float(body[11])]
-        self.max_temperature = [float(body[15]), float(body[10])]
+        self.temperature_min = [float(body[16]), float(body[11])]
+        self.temperature_max = [float(body[15]), float(body[10])]
         self.heating_temperature = float(body[17])
         self.bathing_temperature = float(body[12])
         self.heating_leaving_temperature = float(body[14])

--- a/tests/devices/e6/__init__.py
+++ b/tests/devices/e6/__init__.py
@@ -1,0 +1,1 @@
+"""Test E6 device."""

--- a/tests/devices/e6/device_e6_test.py
+++ b/tests/devices/e6/device_e6_test.py
@@ -1,0 +1,67 @@
+"""Test E6 device."""
+
+from unittest.mock import patch
+
+import pytest
+
+from midealocal.const import ProtocolVersion
+from midealocal.devices.e6 import DeviceAttributes, MideaE6Device
+
+
+class TestMideaE6Device:
+    """Test E6 device."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_device(self) -> None:
+        """Set up E6 device."""
+        self.device = MideaE6Device(
+            name="Test Device",
+            device_id=1,
+            ip_address="192.168.1.100",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="test_model",
+            subtype=1,
+            customize='{"temperature_step": 1}',
+        )
+
+    def test_initial_attributes(self) -> None:
+        """Test initial attributes."""
+        assert self.device.attributes[DeviceAttributes.temperature_min] == [30.0, 35.0]
+        assert self.device.attributes[DeviceAttributes.temperature_max] == [80.0, 60.0]
+
+    def test_process_message(self) -> None:
+        """Test process message."""
+        with patch("midealocal.devices.e6.MessageE6Response") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.main_power = True
+            mock_message.heating_power = False
+            mock_message.heating_working = True
+            mock_message.bathing_working = False
+            mock_message.temperature_min = [25.0, 30.0]
+            mock_message.temperature_max = [75.0, 55.0]
+            mock_message.heating_temperature = 45.0
+            mock_message.bathing_temperature = 40.0
+            mock_message.heating_leaving_temperature = 43.0
+            mock_message.bathing_leaving_temperature = 38.0
+            mock_message.cold_water_single = True
+            mock_message.cold_water_dot = False
+            mock_message.heating_modes = "home_mode"
+
+            result = self.device.process_message(b"")
+
+            assert result[DeviceAttributes.main_power.value] is True
+            assert result[DeviceAttributes.heating_power.value] is False
+            assert result[DeviceAttributes.heating_working.value] is True
+            assert result[DeviceAttributes.bathing_working.value] is False
+            assert result[DeviceAttributes.temperature_min.value] == [25.0, 30.0]
+            assert result[DeviceAttributes.temperature_max.value] == [75.0, 55.0]
+            assert result[DeviceAttributes.heating_temperature.value] == 45.0
+            assert result[DeviceAttributes.bathing_temperature.value] == 40.0
+            assert result[DeviceAttributes.heating_leaving_temperature.value] == 43.0
+            assert result[DeviceAttributes.bathing_leaving_temperature.value] == 38.0
+            assert result[DeviceAttributes.cold_water_single.value] is True
+            assert result[DeviceAttributes.cold_water_dot.value] is False
+            assert result[DeviceAttributes.heating_modes.value] == "home_mode"


### PR DESCRIPTION
Renamed the min_temperature/max_temperature → temperature_min/temperature_max body fields to align with the values ​​in the DeviceAttributes enumeration.

Fix 1 issue of #506