### PR TITLE
fix(e2): removed trailing comma

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -165,10 +165,10 @@ class MideaE2Device(MideaDevice):
         if isinstance(value, str):
             return_value = OldProtocol(value)
             if return_value == OldProtocol.auto:
-                result = (
-                    self.subtype <= E2SubType.T82
-                    or self.subtype in [E2SubType.T85, E2SubType.T36353],
-                )
+                result = self.subtype <= E2SubType.T82 or self.subtype in [
+                    E2SubType.T85,
+                    E2SubType.T36353,
+                ]
                 return_value = OldProtocol.true if result else OldProtocol.false
         if isinstance(value, bool | int):
             return_value = OldProtocol.true if value else OldProtocol.false


### PR DESCRIPTION
Removed the trailing comma that created an always-true tuple in _normalize_old_protocol

Fix 1 issue of #506