### PR TITLE
fix(ac): reject invalid subtype-8 temperatures

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -1089,11 +1089,12 @@ class XBXMessageBody(NewProtocolMessageBody):
                 len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
                 and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
             )
-        if SUBTYPE8_TEMPERATURE_TAG in params:
+        if SUBTYPE8_TEMPERATURE_TAG in params and self._parse_subtype8_temperatures(
+            params[SUBTYPE8_TEMPERATURE_TAG],
+        ):
             self.has_subtype8_temperature = True
-            self._parse_subtype8_temperatures(params[SUBTYPE8_TEMPERATURE_TAG])
 
-    def _parse_subtype8_temperatures(self, data: bytearray) -> None:
+    def _parse_subtype8_temperatures(self, data: bytearray) -> bool:
         """Decode setpoint/indoor temperature for AC subtype 8 (model 22013279).
 
         The standard C0 frame is stale for this subtype; temperatures are
@@ -1103,7 +1104,7 @@ class XBXMessageBody(NewProtocolMessageBody):
         - bit 0x40 adds an extra +0.5C
         """
         if len(data) <= SUBTYPE8_TEMPERATURE_MIN_LENGTH:
-            return
+            return False
         raw_setpoint = data[1]
         target_temperature = (
             SUBTYPE8_SETPOINT_OFFSET + (raw_setpoint & SUBTYPE8_SETPOINT_MASK) / 2
@@ -1124,15 +1125,25 @@ class XBXMessageBody(NewProtocolMessageBody):
                 <= SUBTYPE8_MAX_VALID_TEMPERATURE
             ):
                 target_temperature = fallback_target
-        self.target_temperature = target_temperature
-        self.indoor_temperature = round(
+            else:
+                return False
+        indoor_temperature = round(
             (data[SUBTYPE8_INDOOR_TEMPERATURE_BYTE] - 50) / 2
             + data[SUBTYPE8_INDOOR_TEMPERATURE_DECIMAL_BYTE] * 0.1,
             1,
         )
+        if not (
+            SUBTYPE8_MIN_VALID_TEMPERATURE
+            <= indoor_temperature
+            <= SUBTYPE8_MAX_VALID_TEMPERATURE
+        ):
+            return False
+        self.target_temperature = target_temperature
+        self.indoor_temperature = indoor_temperature
         # Outdoor temperature isn't available locally on this model (the app
         # shows a cloud/weather value); avoid the bogus C0-derived value.
         self.outdoor_temperature = None
+        return True
 
 
 class XB5MessageBody(NewProtocolMessageBody):

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1783,6 +1783,29 @@ class TestMessageACResponse:
         assert hasattr(response, "target_temperature")
         assert response.target_temperature == 25.0
 
+    def test_message_b5_notify2_0x7e_rejects_invalid_indoor_temperature(
+        self,
+    ) -> None:
+        """Ignore a 0x7e payload whose decoded indoor temperature is invalid."""
+        self.header[9] = 0x05
+        body = bytearray(62)
+        body[0] = 0xB5
+        body[1] = 0x01
+        body[2] = 0x7E
+        body[3] = 0x00
+        body[4] = 0x38
+        payload = bytearray(56)
+        payload[1] = 0x1D  # valid 26.0 C setpoint
+        payload[39] = 0x00  # decodes to the reported invalid -25.0 C
+        body[5 : 5 + len(payload)] = payload
+
+        response = MessageACResponse(self.header + body)
+
+        assert not hasattr(response, "has_subtype8_temperature")
+        assert not hasattr(response, "target_temperature")
+        assert not hasattr(response, "indoor_temperature")
+        assert not hasattr(response, "outdoor_temperature")
+
     def test_message_b5_notify2_0x7e_temperature_too_short(self) -> None:
         """Test the 0x7e tag is ignored when shorter than the subtype-8 payload."""
         self.header[9] = 0x05
@@ -1795,8 +1818,7 @@ class TestMessageACResponse:
         body[5 : 5 + 10] = bytearray(10)
 
         response = MessageACResponse(self.header + body)
-        assert hasattr(response, "has_subtype8_temperature")
-        assert response.has_subtype8_temperature is True
+        assert not hasattr(response, "has_subtype8_temperature")
         assert not hasattr(response, "target_temperature")
         assert not hasattr(response, "indoor_temperature")
         assert not hasattr(response, "outdoor_temperature")


### PR DESCRIPTION
Fixes wuwentao/midea_ac_lan#893

Subtype-8 `0x7e` payloads currently become authoritative before their length or decoded values are validated. An unrelated payload can therefore decode the indoor temperature as `-25.0 C` and suppress the valid `C0` room-temperature updates that follow.

This only marks a payload authoritative after both temperatures pass validation, with regressions for the reported sentinel value and truncated payloads. All 125 AC device/message tests pass.
