### PR TITLE
fix(ac): only decode 0x7e temperatures on subtype-8 devices

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -159,6 +159,13 @@ AC_MODEL_CAPABILITIES = {
     ),
 }
 
+# The 0x7e new-protocol temperature payload was decoded from subtype-8 traces
+# (model 22013279). Other subtypes emit tag 0x7e as well, but with unrelated
+# content: on model 22251759 / subtype 32773 the same offsets decode to
+# -15.0 C and permanently suppress the correct C0 temperatures.
+# https://github.com/wuwentao/midea_ac_lan/issues/893
+SUBTYPE8 = 8
+
 STALE_C0_TEMPERATURE_ATTRIBUTES = (
     DeviceAttributes.target_temperature,
     DeviceAttributes.indoor_temperature,
@@ -318,6 +325,8 @@ class MideaACDevice(MideaDevice):
         self._customize_max_temperature: float | None = None
         self._power_analysis_method: int = 1
         self._default_power_analysis_method: int = 1
+        # Only subtype-8 devices carry temperatures in the 0x7e payload.
+        self._subtype8_temperature: bool = int(self.subtype) == SUBTYPE8
         # Once 0x7e-derived temperatures are seen, ignore stale C0 temperature
         # fields to avoid brief UI flicker caused by query ordering.
         self._prefer_new_protocol_temperature: bool = False
@@ -386,7 +395,11 @@ class MideaACDevice(MideaDevice):
 
     def process_message(self, msg: bytes) -> dict[str, Any]:  # noqa: C901
         """Midea AC device process message."""
-        message = MessageACResponse(bytearray(msg), self._power_analysis_method)
+        message = MessageACResponse(
+            bytearray(msg),
+            self._power_analysis_method,
+            self._subtype8_temperature,
+        )
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         has_fresh_air = False

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -1042,7 +1042,12 @@ class XA1MessageBody(XMessageBody):
 class XBXMessageBody(NewProtocolMessageBody):
     """AC BX message body. body[0] b0/b1, body[1] propertyNumber, cursor 2."""
 
-    def __init__(self, body: bytearray, bt: int) -> None:
+    def __init__(
+        self,
+        body: bytearray,
+        bt: int,
+        subtype8_temperature: bool = False,
+    ) -> None:
         """Initialize AC BX message body."""
         super().__init__(body, bt)
 
@@ -1089,8 +1094,10 @@ class XBXMessageBody(NewProtocolMessageBody):
                 len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
                 and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
             )
-        if SUBTYPE8_TEMPERATURE_TAG in params and self._parse_subtype8_temperatures(
-            params[SUBTYPE8_TEMPERATURE_TAG],
+        if (
+            subtype8_temperature
+            and SUBTYPE8_TEMPERATURE_TAG in params
+            and self._parse_subtype8_temperatures(params[SUBTYPE8_TEMPERATURE_TAG])
         ):
             self.has_subtype8_temperature = True
 
@@ -1102,6 +1109,10 @@ class XBXMessageBody(NewProtocolMessageBody):
         setpoint in byte 1:
         - low 6 bits encode 0.5C steps with a +11.5C offset
         - bit 0x40 adds an extra +0.5C
+
+        Only call this for subtype-8 devices: other subtypes send tag 0x7e with
+        unrelated content, where these offsets decode to a bogus temperature
+        that would then suppress their valid C0 temperatures.
         """
         if len(data) <= SUBTYPE8_TEMPERATURE_MIN_LENGTH:
             return False
@@ -1542,7 +1553,12 @@ class XBBMessageBody(MessageBody):
 class MessageACResponse(MessageResponse):
     """AC message response."""
 
-    def __init__(self, message: bytearray, power_analysis_method: int = 3) -> None:
+    def __init__(
+        self,
+        message: bytearray,
+        power_analysis_method: int = 3,
+        subtype8_temperature: bool = False,
+    ) -> None:
         """Initialize AC message response."""
         super().__init__(message)
         # dataType 0x05 and messageBytes[0] 0xA0
@@ -1565,7 +1581,9 @@ class MessageACResponse(MessageResponse):
             MessageType.set,
             MessageType.notify2,
         ] and self.body_type in [ListTypes.B0, ListTypes.B1, ListTypes.B5]:
-            self.set_body(XBXMessageBody(super().body, self.body_type))
+            self.set_body(
+                XBXMessageBody(super().body, self.body_type, subtype8_temperature),
+            )
         # dataType 0x02 and messageBytes[0] 0xC0
         # dataType 0x03 and messageBytes[0] 0xC0
         elif (

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -669,6 +669,45 @@ class TestMideaACDevice:
             assert self.device.attributes[DeviceAttributes.target_temperature] == 27.0
             assert self.device.attributes[DeviceAttributes.indoor_temperature] == 28.8
 
+    @staticmethod
+    def _new_protocol_temperature_response() -> bytes:
+        """Build a B1 query frame carrying a valid 0x7e temperature payload."""
+        body = bytearray(62)
+        body[0] = 0xB1
+        body[1] = 0x01  # one property
+        body[2] = 0x7E  # tag 0x7e, low byte
+        body[3] = 0x00  # tag 0x7e, high byte
+        body[4] = 0x00  # fixed byte of the 5-byte pack
+        body[5] = 0x38  # payload length: 56
+        payload = bytearray(56)
+        payload[1] = 0x1D  # 26.0 C setpoint
+        payload[39] = 0x6A  # 28.8 C indoor temperature
+        payload[40] = 0x08
+        body[6 : 6 + len(payload)] = payload
+        header = bytearray([0xAA, 0, 0xAC, 0, 0, 0, 0, 0, 1, 3])
+        header[1] = len(header) + len(body)
+        frame = header + body
+        frame.append(MessageBase.checksum(frame[1:]))
+        return bytes(frame)
+
+    def test_process_message_0x7e_temperatures_are_gated_by_subtype(self) -> None:
+        """Only subtype-8 devices take their temperatures from the 0x7e tag."""
+        frame = self._new_protocol_temperature_response()
+
+        subtype8 = self._make_device("22013279", 8)
+        status = subtype8.process_message(frame)
+        assert status[DeviceAttributes.target_temperature.value] == 26.0
+        assert status[DeviceAttributes.indoor_temperature.value] == 28.8
+        assert subtype8._prefer_new_protocol_temperature
+
+        # Other subtypes send tag 0x7e with unrelated content, so it must not
+        # overwrite - nor latch out - their valid C0 temperatures.
+        other = self._make_device("22251759", 32773)
+        status = other.process_message(frame)
+        assert DeviceAttributes.target_temperature.value not in status
+        assert DeviceAttributes.indoor_temperature.value not in status
+        assert not other._prefer_new_protocol_temperature
+
     def test_power_saving_control(self) -> None:
         """Test power saving control and preset exclusivity."""
         with patch.object(self.device, "build_send") as mock_build_send:

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1698,7 +1698,7 @@ class TestMessageACResponse:
         )
         body[5 : 5 + len(payload)] = payload
 
-        response = MessageACResponse(self.header + body)
+        response = MessageACResponse(self.header + body, subtype8_temperature=True)
         assert hasattr(response, "has_subtype8_temperature")
         assert response.has_subtype8_temperature is True
         assert hasattr(response, "target_temperature")
@@ -1779,7 +1779,7 @@ class TestMessageACResponse:
         )
         body[5 : 5 + len(payload)] = payload
 
-        response = MessageACResponse(self.header + body)
+        response = MessageACResponse(self.header + body, subtype8_temperature=True)
         assert hasattr(response, "target_temperature")
         assert response.target_temperature == 25.0
 
@@ -1799,7 +1799,7 @@ class TestMessageACResponse:
         payload[39] = 0x00  # decodes to the reported invalid -25.0 C
         body[5 : 5 + len(payload)] = payload
 
-        response = MessageACResponse(self.header + body)
+        response = MessageACResponse(self.header + body, subtype8_temperature=True)
 
         assert not hasattr(response, "has_subtype8_temperature")
         assert not hasattr(response, "target_temperature")
@@ -1817,7 +1817,31 @@ class TestMessageACResponse:
         body[4] = 0x0A  # length 10, at/below SUBTYPE8_TEMPERATURE_MIN_LENGTH
         body[5 : 5 + 10] = bytearray(10)
 
+        response = MessageACResponse(self.header + body, subtype8_temperature=True)
+        assert not hasattr(response, "has_subtype8_temperature")
+        assert not hasattr(response, "target_temperature")
+        assert not hasattr(response, "indoor_temperature")
+        assert not hasattr(response, "outdoor_temperature")
+
+    def test_message_b5_notify2_0x7e_ignored_without_subtype8(self) -> None:
+        """Test the 0x7e tag is ignored when the device is not subtype 8."""
+        self.header[9] = 0x05
+        body = bytearray(62)
+        body[0] = 0xB5
+        body[1] = 0x01
+        body[2] = 0x7E
+        body[3] = 0x00
+        body[4] = 0x38
+        payload = bytearray(56)
+        payload[1] = 0x1D  # decodes to a plausible 26.0 C setpoint
+        payload[39] = 0x6A  # decodes to a plausible 28.8 C indoor temperature
+        payload[40] = 0x08
+        body[5 : 5 + len(payload)] = payload
+
         response = MessageACResponse(self.header + body)
+
+        # The payload decodes to in-range temperatures, so only the subtype
+        # gate keeps another model's unrelated 0x7e content out.
         assert not hasattr(response, "has_subtype8_temperature")
         assert not hasattr(response, "target_temperature")
         assert not hasattr(response, "indoor_temperature")


### PR DESCRIPTION
## Summary

The `0x7e` new-protocol temperature payload is decoded for **every** AC that reports the tag, even though the offsets were reverse-engineered from subtype-8 traces (model 22013279). Other subtypes send tag `0x7e` with unrelated content, and the same offsets then decode to a bogus room temperature that permanently suppresses the valid `C0` temperatures.

This gates the decoding on the device subtype.

## Reproduction

Home Assistant `midea_ac_lan` 0.7.0 (`midea-local==6.11.0`), AC model **22251759**, subtype **32773**, protocol 3. The room temperature sensor sits at **-15.0 °C** and the outdoor temperature entity has no value at all, while the AC itself is fine.

Debug capture from the device — the same query round trip, two frames:

```
B1: b1017e000037a05b40667f7f003f004800000000000000000000000400200000
    000000000000008028281e040000640800002400200000000000000000001f
    -> has_subtype8_temperature: True, target 25.5, indoor -15.0, outdoor None

C0: c00159667f7f003f00080064740d005600000080800000005802000037ffcaf8
    -> target 25.5, indoor 25.6, outdoor 33.5
```

The `C0` frame is correct (25.6 °C indoor, 33.5 °C outdoor, matching the T4 sensor from the `C1` group query). It is discarded.

In the `0x7e` payload of that B1 frame, `data[39] = 0x00` and `data[40] = 0x64`:

```
(0x00 - 50) / 2 + 0x64 * 0.1 = -25 + 10.0 = -15.0
```

`_parse_subtype8_temperatures` also forces `outdoor_temperature = None`, and `process_message` latches `_prefer_new_protocol_temperature`, so from the first B1 frame onwards every `C0` frame has its target/indoor/outdoor temperature skipped for the rest of the session.

## Why the range check isn't enough

#563 rejects a payload whose decoded temperatures fall outside 10–40 °C, which does hide this particular device's symptom. But it is a heuristic over bytes that mean something else entirely on other models: any unrelated payload that happens to decode into 10–40 °C still latches `_prefer_new_protocol_temperature` and permanently suppresses valid `C0` temperatures — this time with a plausible-looking wrong value, which is harder to notice and to report.

## Changes

- `MessageACResponse` / `XBXMessageBody` take a `subtype8_temperature` flag (default `False`), threaded the same way as the existing `power_analysis_method`; the `0x7e` tag is only decoded when it is set.
- `MideaACDevice` sets it from `subtype == 8`.
- The range validation from #563 is kept as a second line of defence for subtype-8 devices.

Gating on the subtype alone rather than an exact `(model, subtype)` pair in `AC_MODEL_CAPABILITIES` keeps every subtype-8 device working, including models other than 22013279 — #501 mentions "some subtype-8 devices". Happy to switch to the exact-pair mechanism if you prefer that consistency.

## Tests

- The four existing `0x7e` cases now pass `subtype8_temperature=True`.
- New message-level case: a payload decoding to **in-range** 26.0 / 28.8 °C is still ignored when the device isn't subtype 8 — the case the range check cannot catch.
- New device-level case: the same B1 frame is adopted by a subtype-8 device (and latches) but ignored by model 22251759 / subtype 32773, which keeps its `C0` temperatures.

`pytest`: 1452 passed. `mypy` and `pylint` (10.00/10) clean; `ruff check` / `ruff format` unchanged from the pre-change baseline.

Fixes wuwentao/midea_ac_lan#893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
