### PR TITLE
build: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
All tracked files are already LF; this codifies it so future commits (including from Windows editors) can't reintroduce CRLF.