### PR TITLE
fix(ac): make screen_display switch idempotent

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -798,8 +798,17 @@ class MideaACDevice(MideaDevice):
                 self._attributes[DeviceAttributes.prompt_tone] = value
                 self.update_all({DeviceAttributes.prompt_tone.value: value})
             elif attr == DeviceAttributes.screen_display:
-                message = MessageToggleDisplay(self._message_protocol_version)
-                message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
+                # The AC firmware only exposes a toggle command for the
+                # display, so make the switch idempotent: toggle only when the
+                # requested state differs from the last reported state.
+                # Otherwise repeated turn_on/turn_off service calls alternate
+                # the physical display instead of setting an absolute state.
+                # https://github.com/wuwentao/midea_ac_lan/issues/623
+                if bool(value) != bool(
+                    self._attributes[DeviceAttributes.screen_display],
+                ):
+                    message = MessageToggleDisplay(self._message_protocol_version)
+                    message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
             elif self._model_capabilities.has_bb_fresh_air and attr in {
                 DeviceAttributes.fresh_air_power,
                 DeviceAttributes.fresh_air_fan_speed,

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -23,6 +23,7 @@ from midealocal.devices.ac.message import (
     MessageSubProtocolQuery10,
     MessageSubProtocolQuery11,
     MessageSubProtocolQuery30,
+    MessageToggleDisplay,
     PowerFormats,
 )
 from midealocal.message import ListTypes, MessageBase
@@ -207,6 +208,37 @@ class TestMideaACDevice:
             self.device.set_attribute(DeviceAttributes.fresh_air_mode.value, "off")
             message = mock_build_send.call_args[0][0]
             assert message.fresh_air_1 == [False, 0]
+
+    def test_set_screen_display_is_idempotent(self) -> None:
+        """screen_display toggles only when the requested state differs.
+
+        The firmware exposes a toggle-only command, so setting the switch to
+        its current state must send nothing; only a differing request emits a
+        single MessageToggleDisplay.
+        https://github.com/wuwentao/midea_ac_lan/issues/623
+        """
+        with patch.object(self.device, "build_send") as mock_build_send:
+            # Currently off: turning off again is a no-op.
+            self.device._attributes[DeviceAttributes.screen_display] = False
+            self.device.set_attribute(DeviceAttributes.screen_display.value, False)
+            mock_build_send.assert_not_called()
+
+            # Currently off: turning on sends one toggle.
+            self.device.set_attribute(DeviceAttributes.screen_display.value, True)
+            mock_build_send.assert_called_once()
+            assert isinstance(mock_build_send.call_args[0][0], MessageToggleDisplay)
+
+            mock_build_send.reset_mock()
+
+            # Currently on: turning on again is a no-op.
+            self.device._attributes[DeviceAttributes.screen_display] = True
+            self.device.set_attribute(DeviceAttributes.screen_display.value, True)
+            mock_build_send.assert_not_called()
+
+            # Currently on: turning off sends one toggle.
+            self.device.set_attribute(DeviceAttributes.screen_display.value, False)
+            mock_build_send.assert_called_once()
+            assert isinstance(mock_build_send.call_args[0][0], MessageToggleDisplay)
 
     def test_set_attribute_eco_mode_resets_exclusive_modes(self) -> None:
         """Test eco mode set resets comfort and frost protect on general set."""


### PR DESCRIPTION
## Summary

The `screen_display` branch in `MideaACDevice.set_attribute` always built a `MessageToggleDisplay`, discarding the requested boolean value. Because the AC firmware only exposes a *toggle* command for the display, repeated `switch.turn_on` / `switch.turn_off` service calls **alternated** the physical display instead of setting an absolute state — e.g. calling `turn_off` on a display that was already off turned it **on**.

This makes the switch idempotent: the toggle is sent only when the requested value differs from the last reported `screen_display` state.

- requested `on`  + already `on`  → send nothing
- requested `off` + already `off` → send nothing
- requested state differs         → send exactly one toggle

This restores normal Home Assistant switch semantics on top of the toggle-only device command, while leaving the existing behaviour (`process_message` forces `screen_display=False` when the unit is powered off) intact.

## Changes

- `midealocal/devices/ac/__init__.py`: guard the `MessageToggleDisplay` send with a `bool(value) != bool(current)` comparison.

## Tests

- Added `test_set_screen_display_is_idempotent` covering all four combinations of requested value vs. cached state, asserting `build_send` fires exactly once for the two differing cases and not at all for the two matching cases.

## Verification

- `uv run python -m pytest tests/devices/ac/` — 131 passed
- `uvx ruff@0.6.9 check` / `format --check` — clean
- `uv run mypy midealocal` — Success
- `uv run pylint --rcfile=pylintrc midealocal` — 10.00/10

## Related

Fixes the root cause reported downstream in wuwentao/midea_ac_lan#623 (comment https://github.com/wuwentao/midea_ac_lan/issues/623#issuecomment-5136933303).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen display settings now update reliably without repeatedly toggling when the requested state is unchanged.
  * Changing the display state sends only one command, preventing unintended alternating behavior.

* **Tests**
  * Added coverage to verify consistent display updates for both matching and changed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->