### PR TITLE
chore: force last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "include-commit-authors": true,
+  "last-release-sha": "feeab8165d796cc1d5b1045f0593724d75d0ed13",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
SHA calculated via `git rev-list -n 1 v6.11.1`, where ver 6.11.1 was the latest released version at that time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to track the latest release commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->