### PR TITLE
chore: revert force last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "include-commit-authors": true,
-  "last-release-sha": "feeab8165d796cc1d5b1045f0593724d75d0ed13",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Reverting after fixing release with #608 and #609.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration by removing a pinned previous-release reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->