### PR TITLE
fix(ca): transmit translated values

### DIFF
--- a/midealocal/devices/ca/__init__.py
+++ b/midealocal/devices/ca/__init__.py
@@ -115,7 +115,7 @@ class MideaCADevice(MideaDevice):
                     self._attributes[attr] = MideaCADevice._humidity.get(value)
                 else:
                     self._attributes[attr] = value
-                new_status[str(attr)] = getattr(message, str(attr))
+                new_status[str(attr)] = self._attributes[attr]
         return new_status
 
     def set_attribute(self, attr: str, value: bool | int | str) -> None:

--- a/tests/devices/ca/device_ca_test.py
+++ b/tests/devices/ca/device_ca_test.py
@@ -117,8 +117,8 @@ class TestMideaCADevice:
         assert self.device.attributes[DeviceAttributes.electronic_smell] is True
         assert self.device.attributes[DeviceAttributes.humidity] == "high"
         assert self.device.attributes[DeviceAttributes.variable_mode] == "soft_freezing"
-        assert new_status[DeviceAttributes.humidity.value] == 0x10
-        assert new_status[DeviceAttributes.variable_mode.value] == 0x01
+        assert new_status[DeviceAttributes.humidity.value] == "high"
+        assert new_status[DeviceAttributes.variable_mode.value] == "soft_freezing"
         assert new_status[DeviceAttributes.energy_consumption.value] == 272
 
     def test_process_message_general_unknown_mappings(self) -> None:


### PR DESCRIPTION
CA pushed the raw protocol byte to update_all() while storing the translated string ("high" vs 0x10) in self._attributes — push subscribers and device.attributes reads disagreed. Every other device reports the translated value in both places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device status updates now consistently report decoded humidity and variable mode values.
  * Returned status information now matches the device’s current interpreted state rather than raw protocol data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->