### PR TITLE
fix(cf): attribute values validation

### DIFF
--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -96,14 +96,20 @@ class MideaCFDevice(MideaDevice):
         elif attr == DeviceAttributes.mode:
             if isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected int")
-            mode_value = float(value)
+            try:
+                mode_value = float(value)
+            except ValueError as err:
+                raise ValueWrongType("[cf] Expected int") from err
             if not mode_value.is_integer():
                 raise ValueWrongType("[cf] Expected int")
             message.mode = int(mode_value)
         elif attr == DeviceAttributes.target_temperature:
             if isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected float")
-            temperature_value = float(value)
+            try:
+                temperature_value = float(value)
+            except ValueError as err:
+                raise ValueWrongType("[cf] Expected float") from err
             if not math.isfinite(temperature_value):
                 raise ValueWrongType("[cf] Expected float")
             message.target_temperature = temperature_value

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -84,6 +84,18 @@ class MideaCFDevice(MideaDevice):
             message.mode = mode
         self.build_send(message)
 
+    @staticmethod
+    def _parse_float(value: bool | float | str, expected: str) -> float:
+        if isinstance(value, bool):
+            raise ValueWrongType(f"[cf] Expected {expected}")
+        try:
+            number = float(value)
+        except (TypeError, ValueError) as err:
+            raise ValueWrongType(f"[cf] Expected {expected}") from err
+        if not math.isfinite(number):
+            raise ValueWrongType(f"[cf] Expected {expected}")
+        return number
+
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CF device set attribute."""
         message = MessageSet(self._message_protocol_version)
@@ -94,25 +106,12 @@ class MideaCFDevice(MideaDevice):
                 raise ValueWrongType("[cf] Expected bool")
             setattr(message, attr, value)
         elif attr == DeviceAttributes.mode:
-            if isinstance(value, bool):
-                raise ValueWrongType("[cf] Expected int")
-            try:
-                mode_value = float(value)
-            except ValueError as err:
-                raise ValueWrongType("[cf] Expected int") from err
+            mode_value = self._parse_float(value, "int")
             if not mode_value.is_integer():
                 raise ValueWrongType("[cf] Expected int")
             message.mode = int(mode_value)
         elif attr == DeviceAttributes.target_temperature:
-            if isinstance(value, bool):
-                raise ValueWrongType("[cf] Expected float")
-            try:
-                temperature_value = float(value)
-            except ValueError as err:
-                raise ValueWrongType("[cf] Expected float") from err
-            if not math.isfinite(temperature_value):
-                raise ValueWrongType("[cf] Expected float")
-            message.target_temperature = temperature_value
+            message.target_temperature = self._parse_float(value, "float")
         else:
             raise ValueError(f"[cf] Unsupported attribute: {attr}")
         self.build_send(message)

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -1,6 +1,7 @@
 """Midea local CF device."""
 
 import logging
+import math
 from enum import StrEnum
 from typing import Any, Unpack
 
@@ -88,23 +89,24 @@ class MideaCFDevice(MideaDevice):
         message = MessageSet(self._message_protocol_version)
         message.power = True
         message.mode = self._attributes[DeviceAttributes.mode]
-        if attr == DeviceAttributes.power:
+        if attr in (DeviceAttributes.power, DeviceAttributes.aux_heating):
             if not isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected bool")
-            message.power = value
+            setattr(message, attr, value)
         elif attr == DeviceAttributes.mode:
             if isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected int")
-            message.power = True
-            message.mode = int(value)
+            mode_value = float(value)
+            if not mode_value.is_integer():
+                raise ValueWrongType("[cf] Expected int")
+            message.mode = int(mode_value)
         elif attr == DeviceAttributes.target_temperature:
             if isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected float")
-            message.target_temperature = float(value)
-        elif attr == DeviceAttributes.aux_heating:
-            if not isinstance(value, bool):
-                raise ValueWrongType("[cf] Expected bool")
-            message.aux_heating = value
+            temperature_value = float(value)
+            if not math.isfinite(temperature_value):
+                raise ValueWrongType("[cf] Expected float")
+            message.target_temperature = temperature_value
         else:
             raise ValueError(f"[cf] Unsupported attribute: {attr}")
         self.build_send(message)

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -93,14 +93,20 @@ class MideaCFDevice(MideaDevice):
                 raise ValueWrongType("[cf] Expected bool")
             message.power = value
         elif attr == DeviceAttributes.mode:
+            if isinstance(value, bool):
+                raise ValueWrongType("[cf] Expected int")
             message.power = True
             message.mode = int(value)
         elif attr == DeviceAttributes.target_temperature:
+            if isinstance(value, bool):
+                raise ValueWrongType("[cf] Expected float")
             message.target_temperature = float(value)
         elif attr == DeviceAttributes.aux_heating:
             if not isinstance(value, bool):
                 raise ValueWrongType("[cf] Expected bool")
             message.aux_heating = value
+        else:
+            raise ValueError(f"[cf] Unsupported attribute: {attr}")
         self.build_send(message)
 
 

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -85,19 +85,21 @@ class MideaCFDevice(MideaDevice):
 
     def set_attribute(self, attr: str, value: bool | int | str) -> None:
         """Midea CF device set attribute."""
-        if not isinstance(value, bool):
-            raise ValueWrongType("[cf] Expected bool")
         message = MessageSet(self._message_protocol_version)
         message.power = True
         message.mode = self._attributes[DeviceAttributes.mode]
         if attr == DeviceAttributes.power:
+            if not isinstance(value, bool):
+                raise ValueWrongType("[cf] Expected bool")
             message.power = value
         elif attr == DeviceAttributes.mode:
             message.power = True
-            message.mode = value
+            message.mode = int(value)
         elif attr == DeviceAttributes.target_temperature:
-            message.target_temperature = value
+            message.target_temperature = float(value)
         elif attr == DeviceAttributes.aux_heating:
+            if not isinstance(value, bool):
+                raise ValueWrongType("[cf] Expected bool")
             message.aux_heating = value
         self.build_send(message)
 

--- a/tests/devices/cf/device_cf_test.py
+++ b/tests/devices/cf/device_cf_test.py
@@ -155,36 +155,58 @@ class TestMideaCFDevice:
             assert message.target_temperature == 30
 
     @pytest.mark.parametrize(
-        ("attr", "value"),
+        ("attr", "value", "expected"),
         [
-            (DeviceAttributes.power, True),
-            (DeviceAttributes.mode, 2),
-            (DeviceAttributes.target_temperature, 30),
-            (DeviceAttributes.aux_heating, True),
+            (DeviceAttributes.power, True, True),
+            (DeviceAttributes.mode, 2, 2),
+            (DeviceAttributes.mode, "2", 2),
+            (DeviceAttributes.target_temperature, 30, 30.0),
+            (DeviceAttributes.aux_heating, True, True),
         ],
     )
     def test_set_attribute(
         self,
         attr: DeviceAttributes,
-        value: bool | int,
+        value: bool | int | str,
+        expected: bool | float,
     ) -> None:
-        """Test set attribute sends a set message."""
+        """Test set attribute sends a set message with the converted value."""
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(attr.value, value)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
             assert isinstance(message, MessageSet)
-            assert getattr(message, attr.value) == value
+            actual = getattr(message, attr.value)
+            assert actual == expected
+            assert type(actual) is type(expected)
 
     @pytest.mark.parametrize(
-        "attr",
-        [DeviceAttributes.power, DeviceAttributes.aux_heating],
+        ("attr", "value"),
+        [
+            (DeviceAttributes.power, 5),
+            (DeviceAttributes.aux_heating, 5),
+            (DeviceAttributes.mode, True),
+            (DeviceAttributes.target_temperature, True),
+        ],
     )
-    def test_set_attribute_wrong_type(self, attr: DeviceAttributes) -> None:
-        """Test set attribute with a non-bool value raises and does not send."""
+    def test_set_attribute_wrong_type(
+        self,
+        attr: DeviceAttributes,
+        value: bool | int,
+    ) -> None:
+        """Test set attribute with a wrong-type value raises and does not send."""
         with (
             patch.object(self.device, "build_send") as mock_build_send,
             pytest.raises(ValueWrongType),
         ):
-            self.device.set_attribute(attr.value, 5)
+            self.device.set_attribute(attr.value, value)
+        mock_build_send.assert_not_called()
+
+    def test_set_attribute_unsupported(self) -> None:
+        """Test set attribute with an unsupported attribute raises and does not send."""
+        with (
+            patch.object(self.device, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match="Unsupported attribute"),
+        ):
+            self.device.set_attribute(DeviceAttributes.current_temperature.value, 5)
         mock_build_send.assert_not_called()

--- a/tests/devices/cf/device_cf_test.py
+++ b/tests/devices/cf/device_cf_test.py
@@ -192,19 +192,21 @@ class TestMideaCFDevice:
             (DeviceAttributes.target_temperature, float("nan")),
             (DeviceAttributes.mode, "abc"),
             (DeviceAttributes.target_temperature, "abc"),
+            (DeviceAttributes.mode, None),
+            (DeviceAttributes.target_temperature, None),
         ],
     )
     def test_set_attribute_wrong_type(
         self,
         attr: DeviceAttributes,
-        value: bool | float | str,
+        value: bool | float | str | None,
     ) -> None:
         """Test set attribute with a wrong-type value raises and does not send."""
         with (
             patch.object(self.device, "build_send") as mock_build_send,
             pytest.raises(ValueWrongType),
         ):
-            self.device.set_attribute(attr.value, value)
+            self.device.set_attribute(attr.value, value)  # type: ignore[arg-type]
         mock_build_send.assert_not_called()
 
     def test_set_attribute_unsupported(self) -> None:

--- a/tests/devices/cf/device_cf_test.py
+++ b/tests/devices/cf/device_cf_test.py
@@ -190,12 +190,14 @@ class TestMideaCFDevice:
             (DeviceAttributes.mode, 2.5),
             (DeviceAttributes.target_temperature, float("inf")),
             (DeviceAttributes.target_temperature, float("nan")),
+            (DeviceAttributes.mode, "abc"),
+            (DeviceAttributes.target_temperature, "abc"),
         ],
     )
     def test_set_attribute_wrong_type(
         self,
         attr: DeviceAttributes,
-        value: bool | float,
+        value: bool | float | str,
     ) -> None:
         """Test set attribute with a wrong-type value raises and does not send."""
         with (

--- a/tests/devices/cf/device_cf_test.py
+++ b/tests/devices/cf/device_cf_test.py
@@ -155,27 +155,36 @@ class TestMideaCFDevice:
             assert message.target_temperature == 30
 
     @pytest.mark.parametrize(
-        "attr",
+        ("attr", "value"),
         [
-            DeviceAttributes.power,
-            DeviceAttributes.mode,
-            DeviceAttributes.target_temperature,
-            DeviceAttributes.aux_heating,
+            (DeviceAttributes.power, True),
+            (DeviceAttributes.mode, 2),
+            (DeviceAttributes.target_temperature, 30),
+            (DeviceAttributes.aux_heating, True),
         ],
     )
-    def test_set_attribute(self, attr: DeviceAttributes) -> None:
+    def test_set_attribute(
+        self,
+        attr: DeviceAttributes,
+        value: bool | int,
+    ) -> None:
         """Test set attribute sends a set message."""
         with patch.object(self.device, "build_send") as mock_build_send:
-            self.device.set_attribute(attr.value, True)
+            self.device.set_attribute(attr.value, value)
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
             assert isinstance(message, MessageSet)
+            assert getattr(message, attr.value) == value
 
-    def test_set_attribute_wrong_type(self) -> None:
+    @pytest.mark.parametrize(
+        "attr",
+        [DeviceAttributes.power, DeviceAttributes.aux_heating],
+    )
+    def test_set_attribute_wrong_type(self, attr: DeviceAttributes) -> None:
         """Test set attribute with a non-bool value raises and does not send."""
         with (
             patch.object(self.device, "build_send") as mock_build_send,
             pytest.raises(ValueWrongType),
         ):
-            self.device.set_attribute(DeviceAttributes.power.value, 5)
+            self.device.set_attribute(attr.value, 5)
         mock_build_send.assert_not_called()

--- a/tests/devices/cf/device_cf_test.py
+++ b/tests/devices/cf/device_cf_test.py
@@ -187,12 +187,15 @@ class TestMideaCFDevice:
             (DeviceAttributes.aux_heating, 5),
             (DeviceAttributes.mode, True),
             (DeviceAttributes.target_temperature, True),
+            (DeviceAttributes.mode, 2.5),
+            (DeviceAttributes.target_temperature, float("inf")),
+            (DeviceAttributes.target_temperature, float("nan")),
         ],
     )
     def test_set_attribute_wrong_type(
         self,
         attr: DeviceAttributes,
-        value: bool | int,
+        value: bool | float,
     ) -> None:
         """Test set attribute with a wrong-type value raises and does not send."""
         with (


### PR DESCRIPTION
CF's set_attribute() rejected any non-bool value up front, but mode (int) and target_temperature (float) were handled a few lines below that same guard — those two attributes could never actually be set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Device attribute updates now validate and convert values according to their expected types.
  - Power and auxiliary heating settings accept boolean values.
  - Operating modes accept integer-valued numeric inputs, while target temperatures accept finite numeric values.
  - Invalid, non-finite, or unsupported values are rejected without sending an update.
  - Unsupported attributes now return a clear validation error.
  - Valid settings are sent using the correct data types for reliable device control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->