### PR TITLE
fix(b6): turn_on evaluation

### DIFF
--- a/midealocal/devices/b6/__init__.py
+++ b/midealocal/devices/b6/__init__.py
@@ -132,7 +132,7 @@ class MideaB6Device(MideaDevice):
             message.fan_level = list(self._speeds.keys())[fan_speed]
         else:
             message.fan_level = self._power_speed
-        if mode is not None in self._speeds.values():
+        if mode is not None and mode in self._speeds.values():
             message.fan_level = list(self._speeds.keys())[
                 list(self._speeds.values()).index(mode)
             ]

--- a/tests/devices/b6/device_b6_test.py
+++ b/tests/devices/b6/device_b6_test.py
@@ -161,14 +161,16 @@ class TestMideaB6Device:
             mock_build_send.assert_called_once()
 
     def test_turn_on_with_mode(self) -> None:
-        """Test turn on with a mode when a speed maps to None."""
-        # The mode branch uses a chained comparison that requires None to be
-        # one of the configured speed values, which is only possible through
-        # a customize payload containing a null speed name.
-        self.device.set_customize('{"speeds": {"0": null, "1": "Low"}}')
+        """Test turn on with a mode name applies the matching fan level."""
         with patch.object(self.device, "build_send") as mock_build_send:
-            self.device.turn_on(mode="Low")
+            self.device.turn_on(mode="Level 1")
             mock_build_send.assert_called_once()
+            assert mock_build_send.call_args[0][0].fan_level == 1
+            mock_build_send.reset_mock()
+
+            self.device.turn_on(mode="invalid")
+            mock_build_send.assert_called_once()
+            assert mock_build_send.call_args[0][0].fan_level == self.device._power_speed
 
     def test_set_customize(self) -> None:
         """Test set customize."""


### PR DESCRIPTION
B6's turn_on() used a chained comparison (mode is not None in self._speeds.values()) that Python evaluates as mode is not None and None in self._speeds.values(), almost always False. Silently dropped the caller's mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device activation when an optional fan mode is provided.
  * Valid modes now use their configured fan speed.
  * Invalid or unavailable modes safely fall back to the device’s default power speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->