### PR TITLE
fix(fa): turn_on evaluation

### DIFF
--- a/midealocal/devices/fa/__init__.py
+++ b/midealocal/devices/fa/__init__.py
@@ -322,8 +322,8 @@ class MideaFADevice(MideaDevice):
         message.power = True
         if fan_speed is not None:
             message.fan_speed = fan_speed
-        if mode is None:
-            message.mode = mode
+        if mode is not None and mode in MideaFADevice._modes:
+            message.mode = MideaFADevice._modes.index(mode)
         self.build_send(message)
 
     def set_customize(self, customize: str) -> None:

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -436,6 +436,12 @@ class TestMideaFADevice:
             message = mock_build_send.call_args[0][0]
             assert message.power is True
             assert message.fan_speed == 3
+            assert message.mode == 0
+            mock_build_send.reset_mock()
+
+            self.device.turn_on(mode="invalid")
+            mock_build_send.assert_called_once()
+            assert mock_build_send.call_args[0][0].mode is None
 
     def test_set_customize(self) -> None:
         """Test set customize."""


### PR DESCRIPTION
FA's turn_on() only ever set message.mode when mode is None (a no-op); silently dropped the caller's mode.