### PR TITLE
refactor: align set_attribute signature

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -835,7 +835,7 @@ class MideaDevice(threading.Thread):
                     self.close_socket()
                     break
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Set attribute."""
         raise NotImplementedError
 

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -182,7 +182,7 @@ class MideaA1Device(MideaDevice):
         )
         return message
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea A1 device set attribute."""
         if attr == DeviceAttributes.prompt_tone:
             self._attributes[DeviceAttributes.prompt_tone] = value

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -598,7 +598,7 @@ class MideaACDevice(MideaDevice):
     def make_newprotocol_message_set(
         self,
         attr: str,
-        value: bool | int | str,
+        value: bool | float | str,
     ) -> MessageNewProtocolSet:
         """Midea AC device make newprotocol message set."""
         message = MessageNewProtocolSet(self._message_protocol_version)
@@ -694,7 +694,7 @@ class MideaACDevice(MideaDevice):
     def make_subprotocol_fresh_air_set(
         self,
         attr: str,
-        value: bool | int | str,
+        value: bool | float | str,
     ) -> MessageSubProtocolFreshAirSet:
         """Build a BB fresh-air intake or exhaust single-control command."""
         exhaust = attr in {
@@ -761,7 +761,7 @@ class MideaACDevice(MideaDevice):
             message = self.make_message_set()
         return message
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea AC device set attribute."""
         # if nat a sensor
         message: (

--- a/midealocal/devices/ad/__init__.py
+++ b/midealocal/devices/ad/__init__.py
@@ -97,7 +97,7 @@ class MideaADDevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea AD device set attribute."""
 
     def set_customize(self, customize: str) -> None:

--- a/midealocal/devices/b0/__init__.py
+++ b/midealocal/devices/b0/__init__.py
@@ -220,7 +220,7 @@ class MideaB0Device(MideaDevice):
                 new_status[str(attr)] = self._attributes[attr]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """B0 Midea device set attribute."""
 
 

--- a/midealocal/devices/b1/__init__.py
+++ b/midealocal/devices/b1/__init__.py
@@ -81,7 +81,7 @@ class MideaB1Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea B1 device set attribute."""
 
 

--- a/midealocal/devices/b3/__init__.py
+++ b/midealocal/devices/b3/__init__.py
@@ -112,7 +112,7 @@ class MideaB3Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea local B3 device set attribute."""
 
 

--- a/midealocal/devices/b4/__init__.py
+++ b/midealocal/devices/b4/__init__.py
@@ -81,7 +81,7 @@ class MideaB4Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea B4 device set attribute."""
 
 

--- a/midealocal/devices/b6/__init__.py
+++ b/midealocal/devices/b6/__init__.py
@@ -98,7 +98,7 @@ class MideaB6Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea B6 device set attribute."""
         message = None
         if attr == DeviceAttributes.fan_speed:

--- a/midealocal/devices/b8/__init__.py
+++ b/midealocal/devices/b8/__init__.py
@@ -145,7 +145,7 @@ class MideaB8Device(MideaDevice):
         msg = MessageSetCommand(self._message_protocol_version, work_mode=work_mode)
         self.build_send(msg)
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea B8 device set attribute."""
         try:
             msg = self._gen_set_msg_default_values()

--- a/midealocal/devices/bf/__init__.py
+++ b/midealocal/devices/bf/__init__.py
@@ -81,7 +81,7 @@ class MideaBFDevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea BF device set attribute."""
 
 

--- a/midealocal/devices/c2/__init__.py
+++ b/midealocal/devices/c2/__init__.py
@@ -98,7 +98,7 @@ class MideaC2Device(MideaDevice):
                 new_status[str(status)] = getattr(message, str(status))
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea C2 device set attribute."""
         message: MessagePower | MessageSet | None = None
         if attr == DeviceAttributes.power:

--- a/midealocal/devices/ca/__init__.py
+++ b/midealocal/devices/ca/__init__.py
@@ -118,7 +118,7 @@ class MideaCADevice(MideaDevice):
                 new_status[str(attr)] = getattr(message, str(attr))
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CA device set attribute."""
 
 

--- a/midealocal/devices/cc/__init__.py
+++ b/midealocal/devices/cc/__init__.py
@@ -219,7 +219,7 @@ class MideaCCDevice(MideaDevice):
             message.mode = mode
         self.build_send(message)
 
-    def _set_attribute_fe(self, attr: str, value: bool | int | str) -> None:
+    def _set_attribute_fe(self, attr: str, value: bool | float | str) -> None:
         """Set an attribute on a 0xFE VRF panel via key-value control frames."""
         if attr == DeviceAttributes.power:
             self._send_fe_control([(CCControlId.POWER, 1 if value else 0)])
@@ -244,7 +244,7 @@ class MideaCCDevice(MideaDevice):
             self._send_fe_control([(CCControlId.SWING, 0x06 if value else 0x00)])
         # other attributes are not supported by the 0xFE control protocol
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CC device set attribute."""
         if self._is_fe_format:
             self._set_attribute_fe(attr, value)

--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -364,7 +364,7 @@ class MideaCDDevice(MideaDevice):
                 new_status[str(attr)] = self._attributes[attr]
         return new_status
 
-    def set_attribute(self, attr: str, value: str | float | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CD device set attribute."""
         # Maintenance reminder is read-only until the weekly write payload is safe.
         if attr in [

--- a/midealocal/devices/ce/__init__.py
+++ b/midealocal/devices/ce/__init__.py
@@ -125,7 +125,7 @@ class MideaCEDevice(MideaDevice):
         message.child_lock = self._attributes[DeviceAttributes.child_lock]
         return message
 
-    def set_attribute(self, attr: str, value: str | int | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CE device set attribute."""
         message = self.make_message_set()
         if attr == DeviceAttributes.mode:

--- a/midealocal/devices/cf/__init__.py
+++ b/midealocal/devices/cf/__init__.py
@@ -83,7 +83,7 @@ class MideaCFDevice(MideaDevice):
             message.mode = mode
         self.build_send(message)
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea CF device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[cf] Expected bool")

--- a/midealocal/devices/da/__init__.py
+++ b/midealocal/devices/da/__init__.py
@@ -155,7 +155,7 @@ class MideaDADevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea DA device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[da] Expected bool")

--- a/midealocal/devices/db/__init__.py
+++ b/midealocal/devices/db/__init__.py
@@ -279,7 +279,7 @@ class MideaDBDevice(MideaDevice):
                 new_status[str(attr)] = self._attributes[attr]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea DB device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[db] Expected bool")

--- a/midealocal/devices/dc/__init__.py
+++ b/midealocal/devices/dc/__init__.py
@@ -175,7 +175,7 @@ class MideaDCDevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea DC device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[dc] Expected bool")

--- a/midealocal/devices/e1/__init__.py
+++ b/midealocal/devices/e1/__init__.py
@@ -204,7 +204,7 @@ class MideaE1Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea E1 device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[e1] Expected bool")

--- a/midealocal/devices/e8/__init__.py
+++ b/midealocal/devices/e8/__init__.py
@@ -83,7 +83,7 @@ class MideaE8Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea E8 device set attribute."""
 
 

--- a/midealocal/devices/ea/__init__.py
+++ b/midealocal/devices/ea/__init__.py
@@ -181,7 +181,7 @@ class MideaEADevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea EA device set attribute."""
 
 

--- a/midealocal/devices/ec/__init__.py
+++ b/midealocal/devices/ec/__init__.py
@@ -195,7 +195,7 @@ class MideaECDevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea EC device set attribute."""
 
 

--- a/midealocal/devices/ed/__init__.py
+++ b/midealocal/devices/ed/__init__.py
@@ -182,7 +182,7 @@ class MideaEDDevice(MideaDevice):
                 self._attributes[status] = getattr(message, str(status))
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea ED device set attribute."""
         message: MessageNewSet | MessageOldSet | None = None
         if self._use_new_set():

--- a/midealocal/devices/fa/__init__.py
+++ b/midealocal/devices/fa/__init__.py
@@ -261,7 +261,11 @@ class MideaFADevice(MideaDevice):
                     self._attributes[DeviceAttributes.oscillation_angle],
                 )
 
-    def set_oscillation(self, attr: str, value: int | str | bool) -> MessageSet | None:
+    def set_oscillation(
+        self,
+        attr: str,
+        value: bool | float | str,
+    ) -> MessageSet | None:
         """Set oscillation mode."""
         message: MessageSet | None = None
         if self._attributes[attr] != value:
@@ -288,7 +292,7 @@ class MideaFADevice(MideaDevice):
                 self._set_tilting_angle(message, str(value))
         return message
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Set attribute."""
         message = None
         if attr in [

--- a/midealocal/devices/fb/__init__.py
+++ b/midealocal/devices/fb/__init__.py
@@ -85,7 +85,7 @@ class MideaFBDevice(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: str | int | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea FB device set attribute."""
         if attr == DeviceAttributes.mode:
             message = MessageSet(self._message_protocol_version, self.subtype)

--- a/midealocal/devices/fc/__init__.py
+++ b/midealocal/devices/fc/__init__.py
@@ -192,7 +192,7 @@ class MideaFCDevice(MideaDevice):
         message.standby_detect = self._standby_detect
         return message
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea FC device set attribute."""
         if attr == DeviceAttributes.prompt_tone:
             self._attributes[DeviceAttributes.prompt_tone] = value

--- a/midealocal/devices/fd/__init__.py
+++ b/midealocal/devices/fd/__init__.py
@@ -175,7 +175,7 @@ class MideaFDDevice(MideaDevice):
         )
         return message
 
-    def set_attribute(self, attr: str, value: str | int | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea FD device set attribute."""
         if attr == DeviceAttributes.prompt_tone:
             self._attributes[DeviceAttributes.prompt_tone] = value

--- a/midealocal/devices/x13/__init__.py
+++ b/midealocal/devices/x13/__init__.py
@@ -108,7 +108,7 @@ class Midea13Device(MideaDevice):
                     new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: str | int | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea x13 Device set attribute."""
         if attr in [
             DeviceAttributes.brightness,

--- a/midealocal/devices/x26/__init__.py
+++ b/midealocal/devices/x26/__init__.py
@@ -130,7 +130,7 @@ class Midea26Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea x26 device set attribute."""
         if attr in [
             DeviceAttributes.main_light,

--- a/midealocal/devices/x34/__init__.py
+++ b/midealocal/devices/x34/__init__.py
@@ -146,7 +146,7 @@ class Midea34Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: bool | int | str) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea x34 device set attribute."""
         if not isinstance(value, bool):
             raise ValueWrongType("[x34] Expected bool")

--- a/midealocal/devices/x40/__init__.py
+++ b/midealocal/devices/x40/__init__.py
@@ -109,7 +109,7 @@ class MideaX40Device(MideaDevice):
                 new_status[str(status)] = self._attributes[status]
         return new_status
 
-    def set_attribute(self, attr: str, value: int | str | bool) -> None:
+    def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea x40 Device set attribute."""
         if attr in [
             DeviceAttributes.light,


### PR DESCRIPTION
Every device's `set_attribute(attr, value)` override, plus the abstract method in midealocal/device.py, now uses the identical signature value: `bool | float | str`.
Ruff's PYI041 rule caught that int is redundant next to float.