### PR TITLE
fix(ac): report self-clean status correcly

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -512,7 +512,7 @@ class MideaACDevice(MideaDevice):
             if self._pending_self_clean is not None:
                 expected, set_at = self._pending_self_clean
                 elapsed = time.monotonic() - set_at
-                if active == expected or elapsed > self._self_clean_pending_timeout:
+                if active == expected or elapsed >= self._self_clean_pending_timeout:
                     self._pending_self_clean = None
                 else:
                     _LOGGER.debug(

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, ClassVar, Unpack, cast
@@ -311,6 +312,7 @@ class MideaACDevice(MideaDevice):
             dict.fromkeys(self._model_capabilities.attributes),
         )
         self._fresh_air_version: DeviceAttributes | None = None
+        self._pending_self_clean: tuple[bool, float] | None = None
         self._default_temperature_step: float = 0.5
         self._temperature_step: float = 0.5
         self._used_subprotocol: bool = self._model_capabilities.uses_bb_protocol
@@ -502,8 +504,26 @@ class MideaACDevice(MideaDevice):
             self._fresh_air_version = DeviceAttributes.fresh_air_2
         if hasattr(message, "self_clean_active"):
             active = message.self_clean_active
-            self._attributes[DeviceAttributes.self_clean] = active
-            new_status[DeviceAttributes.self_clean.value] = active
+            update_self_clean = True
+            if self._pending_self_clean is not None:
+                expected, set_at = self._pending_self_clean
+                now = time.monotonic()
+                elapsed = now - set_at
+                if active == expected:
+                    self._pending_self_clean = None
+                elif elapsed <= self._self_clean_pending_timeout:
+                    _LOGGER.debug(
+                        "[%s] Ignoring stale self-clean status %s while awaiting %s",
+                        self.device_id,
+                        active,
+                        expected,
+                    )
+                    update_self_clean = False
+                else:
+                    self._pending_self_clean = None
+            if update_self_clean:
+                self._attributes[DeviceAttributes.self_clean] = active
+                new_status[DeviceAttributes.self_clean.value] = active
         new_status.update(self._refresh_temperature_limits(message))
         self._update_capabilities(message)
         return new_status
@@ -523,6 +543,15 @@ class MideaACDevice(MideaDevice):
                 break
             mode = name
         return mode
+
+    @property
+    def _self_clean_pending_timeout(self) -> int:
+        """Return the stale-status window for a pending self-clean command."""
+        return (
+            self._refresh_interval
+            if self._refresh_interval > 0
+            else self._default_refresh_interval
+        )
 
     def _update_capabilities(self, message: MessageACResponse) -> None:
         """Accumulate decoded B5 capability flags from a B5 response."""
@@ -772,6 +801,7 @@ class MideaACDevice(MideaDevice):
             | MessageGeneralSet
             | None
         ) = None
+        optimistic_self_clean: bool | None = None
         if attr not in [
             DeviceAttributes.indoor_temperature,
             DeviceAttributes.outdoor_temperature,
@@ -833,6 +863,8 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.self_clean,
             ]:
                 message = self.make_newprotocol_message_set(attr=attr, value=value)
+                if attr == DeviceAttributes.self_clean:
+                    optimistic_self_clean = bool(value)
             elif attr == DeviceAttributes.power_saving and self._used_subprotocol:
                 _LOGGER.debug(
                     "[%s] Power saving is unsupported by the AC subprotocol",
@@ -868,6 +900,12 @@ class MideaACDevice(MideaDevice):
                         message.fan_speed = 102
         if message is not None:
             self.build_send(message)
+            if optimistic_self_clean is not None:
+                self._pending_self_clean = (optimistic_self_clean, time.monotonic())
+                self._attributes[DeviceAttributes.self_clean] = optimistic_self_clean
+                self.update_all(
+                    {DeviceAttributes.self_clean.value: optimistic_self_clean},
+                )
 
     def set_target_temperature(
         self,

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -22,6 +22,7 @@ from .message import (
     MessageGroupZeroQuery,
     MessageHumidityQuery,
     MessageNewProtocolQuery,
+    MessageNewProtocolSelfCleanQuery,
     MessageNewProtocolSet,
     MessagePowerQuery,
     MessageQuery,
@@ -384,6 +385,9 @@ class MideaACDevice(MideaDevice):
         queries: list[ACQuery] = [
             MessageQuery(self._message_protocol_version),
             MessageNewProtocolQuery(self._message_protocol_version),
+            # Queried on its own so an empty response for the combined
+            # new-protocol query does not suppress the self-clean state.
+            MessageNewProtocolSelfCleanQuery(self._message_protocol_version),
             MessagePowerQuery(self._message_protocol_version),
             MessageHumidityQuery(self._message_protocol_version),
             MessageGroupZeroQuery(self._message_protocol_version),

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -507,11 +507,10 @@ class MideaACDevice(MideaDevice):
             update_self_clean = True
             if self._pending_self_clean is not None:
                 expected, set_at = self._pending_self_clean
-                now = time.monotonic()
-                elapsed = now - set_at
-                if active == expected:
+                elapsed = time.monotonic() - set_at
+                if active == expected or elapsed > self._self_clean_pending_timeout:
                     self._pending_self_clean = None
-                elif elapsed <= self._self_clean_pending_timeout:
+                else:
                     _LOGGER.debug(
                         "[%s] Ignoring stale self-clean status %s while awaiting %s",
                         self.device_id,
@@ -519,8 +518,6 @@ class MideaACDevice(MideaDevice):
                         expected,
                     )
                     update_self_clean = False
-                else:
-                    self._pending_self_clean = None
             if update_self_clean:
                 self._attributes[DeviceAttributes.self_clean] = active
                 new_status[DeviceAttributes.self_clean.value] = active

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -44,8 +44,6 @@ INDIRECT_WIND_VALUE = 0x02
 MAX_MSG_SERIAL_NUM = 254
 OUT_SILENT_VALUE = 0x03
 POWER_SAVING_VALUE = 0x08
-SELF_CLEAN_ACTIVE_STATUS_BYTE = 13
-SELF_CLEAN_ACTIVE_STATUS_VALUE = 0x40
 SCREEN_DISPLAY_BYTE_CHECK = 0x07
 SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
@@ -150,7 +148,9 @@ class NewProtocolTags(IntEnum):
     fresh_air_2 = 0x004B  # queryType == "fresh_air"
     prevent_super_cool = 0x0049
     auto_prevent_straight_wind = 0x0226
-    self_clean = 0x0039  # self_clean query can't return response
+    # Live self-clean status. Reported in B0 (set echo) and B1 (query) bodies.
+    # The same tag in a B5 capability body only advertises support, not state.
+    self_clean = 0x0039
     wind_straight = 0x0032
     wind_avoid = 0x0033
     intelligent_wind = 0x0034
@@ -212,7 +212,6 @@ class NewProtocolTags(IntEnum):
     rate_select = 0x0048
     # AC outdoor silent mode (PortaSplit)
     out_silent = 0x00CD
-    b5_self_clean_active = 0x00E2
 
 
 class MessageACBase(MessageRequest):
@@ -449,6 +448,21 @@ class MessageToggleDisplay(MessageACBase):
 class MessageNewProtocolQuery(MessageACBase):
     """AC message new protocol query."""
 
+    _query_params: tuple[int, ...] = (
+        NewProtocolTags.indirect_wind,
+        NewProtocolTags.breezeless,
+        NewProtocolTags.indoor_humidity,
+        NewProtocolTags.screen_display,
+        NewProtocolTags.fresh_air_1,
+        NewProtocolTags.fresh_air_2,
+        NewProtocolTags.wind_lr_angle,
+        NewProtocolTags.wind_ud_angle,
+        NewProtocolTags.rate_select,
+        NewProtocolTags.out_silent,
+        NewProtocolTags.buzzer_all,
+        NewProtocolQuery.error_code_query,
+    )
+
     def __init__(self, protocol_version: int) -> None:
         """Initialize AC message new protocol query."""
         super().__init__(
@@ -459,26 +473,21 @@ class MessageNewProtocolQuery(MessageACBase):
 
     @property
     def _body(self) -> bytearray:
-        query_params = [
-            NewProtocolTags.indirect_wind,
-            NewProtocolTags.breezeless,
-            NewProtocolTags.indoor_humidity,
-            NewProtocolTags.screen_display,
-            NewProtocolTags.fresh_air_1,
-            NewProtocolTags.fresh_air_2,
-            NewProtocolTags.wind_lr_angle,
-            NewProtocolTags.wind_ud_angle,
-            NewProtocolTags.rate_select,
-            NewProtocolTags.out_silent,
-            NewProtocolTags.buzzer_all,
-            NewProtocolQuery.error_code_query,
-            NewProtocolTags.b5_self_clean_active,
-        ]
-
-        _body = bytearray([len(query_params)])
-        for param in query_params:
+        _body = bytearray([len(self._query_params)])
+        for param in self._query_params:
             _body.extend([param & 0xFF, param >> 8])
         return _body
+
+
+class MessageNewProtocolSelfCleanQuery(MessageNewProtocolQuery):
+    """AC message new protocol self-clean query.
+
+    A device answers with an empty parameter list when a query carries a tag it
+    does not support, which suppresses every other tag in the same request. The
+    self-clean state is therefore asked for as an independent status group.
+    """
+
+    _query_params = (NewProtocolTags.self_clean,)
 
 
 class MessageSubProtocol(MessageACBase):
@@ -1089,15 +1098,10 @@ class XBXMessageBody(NewProtocolMessageBody):
             self.sound = params[NewProtocolTags.buzzer_all][0] > 0
         if NewProtocolQuery.error_code_query in params:
             self.error_code = params[NewProtocolQuery.error_code_query][0]
-        if NewProtocolTags.b5_self_clean_active in params:
-            data = params[NewProtocolTags.b5_self_clean_active]
-            self.self_clean_active: bool = (
-                len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
-                and (
-                    data[SELF_CLEAN_ACTIVE_STATUS_BYTE] & SELF_CLEAN_ACTIVE_STATUS_VALUE
-                )
-                != 0
-            )
+        if NewProtocolTags.self_clean in params and bt != ListTypes.B5:
+            # A B5 body carries this tag as a capability flag (always 1 when the
+            # model supports self-clean), so only B0/B1 bodies report live state.
+            self.self_clean_active: bool = params[NewProtocolTags.self_clean][0] > 0
         if (
             new_protocol_temperature
             and NEW_PROTOCOL_TEMPERATURE_TAG in params

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -44,7 +44,8 @@ INDIRECT_WIND_VALUE = 0x02
 MAX_MSG_SERIAL_NUM = 254
 OUT_SILENT_VALUE = 0x03
 POWER_SAVING_VALUE = 0x08
-SELF_CLEAN_ACTIVE_STATUS_BYTE = 12
+SELF_CLEAN_ACTIVE_STATUS_BYTE = 13
+SELF_CLEAN_ACTIVE_STATUS_VALUE = 0x40
 SCREEN_DISPLAY_BYTE_CHECK = 0x07
 SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
@@ -1092,7 +1093,10 @@ class XBXMessageBody(NewProtocolMessageBody):
             data = params[NewProtocolTags.b5_self_clean_active]
             self.self_clean_active: bool = (
                 len(data) > SELF_CLEAN_ACTIVE_STATUS_BYTE
-                and data[SELF_CLEAN_ACTIVE_STATUS_BYTE] != 0
+                and (
+                    data[SELF_CLEAN_ACTIVE_STATUS_BYTE] & SELF_CLEAN_ACTIVE_STATUS_VALUE
+                )
+                != 0
             )
         if (
             new_protocol_temperature

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -873,6 +873,35 @@ class TestMideaACDevice:
             assert self.device.attributes[DeviceAttributes.self_clean] is False
             assert self.device._pending_self_clean is None
 
+    def test_self_clean_accepts_status_at_refresh_interval_boundary(self) -> None:
+        """Test stale-status guard expires exactly at the configured refresh interval."""
+        with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.power = False
+            mock_message.fresh_air_power = False
+            mock_message.fresh_air_fan_speed = 0
+            mock_message.fresh_air_1 = None
+            mock_message.fresh_air_2 = None
+            mock_message.swing_vertical = False
+            mock_message.indoor_temperature = None
+            mock_message.outdoor_temperature = None
+            mock_message.indoor_humidity = None
+            mock_message.total_energy_consumption = None
+            mock_message.current_energy_consumption = None
+            mock_message.realtime_power = None
+            del mock_message.self_clean
+
+            self.device.set_refresh_interval(5)
+            self.device._pending_self_clean = (True, 100.0)
+            mock_message.self_clean_active = False
+            with patch("midealocal.devices.ac.time.monotonic", return_value=105.0):
+                result = self.device.process_message(b"")
+
+            assert result[DeviceAttributes.self_clean.value] is False
+            assert self.device.attributes[DeviceAttributes.self_clean] is False
+            assert self.device._pending_self_clean is None
+
     def test_set_self_clean_updates_status_after_send(self) -> None:
         """Test self-clean command publishes its requested state after sending."""
         updates: list[dict[str, bool]] = []

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -806,6 +806,104 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.self_clean.value] is False
             assert self.device.attributes[DeviceAttributes.self_clean] is False
 
+    def test_self_clean_ignores_stale_status_after_set(self) -> None:
+        """Test stale self-clean status does not undo a pending command."""
+        with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.power = False
+            mock_message.fresh_air_power = False
+            mock_message.fresh_air_fan_speed = 0
+            mock_message.fresh_air_1 = None
+            mock_message.fresh_air_2 = None
+            mock_message.swing_vertical = False
+            mock_message.indoor_temperature = None
+            mock_message.outdoor_temperature = None
+            mock_message.indoor_humidity = None
+            mock_message.total_energy_consumption = None
+            mock_message.current_energy_consumption = None
+            mock_message.realtime_power = None
+            del mock_message.self_clean
+
+            self.device._pending_self_clean = (True, 100.0)
+            mock_message.self_clean_active = False
+            with patch("midealocal.devices.ac.time.monotonic", return_value=101.0):
+                result = self.device.process_message(b"")
+
+            assert DeviceAttributes.self_clean.value not in result
+            assert self.device.attributes[DeviceAttributes.self_clean] is False
+            assert self.device._pending_self_clean == (True, 100.0)
+
+            mock_message.self_clean_active = True
+            with patch("midealocal.devices.ac.time.monotonic", return_value=102.0):
+                result = self.device.process_message(b"")
+
+            assert result[DeviceAttributes.self_clean.value] is True
+            assert self.device.attributes[DeviceAttributes.self_clean] is True
+            assert self.device._pending_self_clean is None
+
+    def test_self_clean_accepts_status_after_refresh_interval(self) -> None:
+        """Test stale-status guard expires after the configured refresh interval."""
+        with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.used_subprotocol = False
+            mock_message.power = False
+            mock_message.fresh_air_power = False
+            mock_message.fresh_air_fan_speed = 0
+            mock_message.fresh_air_1 = None
+            mock_message.fresh_air_2 = None
+            mock_message.swing_vertical = False
+            mock_message.indoor_temperature = None
+            mock_message.outdoor_temperature = None
+            mock_message.indoor_humidity = None
+            mock_message.total_energy_consumption = None
+            mock_message.current_energy_consumption = None
+            mock_message.realtime_power = None
+            del mock_message.self_clean
+
+            self.device.set_refresh_interval(5)
+            self.device._pending_self_clean = (True, 100.0)
+            mock_message.self_clean_active = False
+            with patch("midealocal.devices.ac.time.monotonic", return_value=106.0):
+                result = self.device.process_message(b"")
+
+            assert result[DeviceAttributes.self_clean.value] is False
+            assert self.device.attributes[DeviceAttributes.self_clean] is False
+            assert self.device._pending_self_clean is None
+
+    def test_set_self_clean_updates_status_after_send(self) -> None:
+        """Test self-clean command publishes its requested state after sending."""
+        updates: list[dict[str, bool]] = []
+        self.device.register_update(updates.append)
+
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.self_clean, True)
+
+        mock_build_send.assert_called_once()
+        assert self.device.attributes[DeviceAttributes.self_clean] is True
+        assert updates == [{DeviceAttributes.self_clean.value: True}]
+        assert self.device._pending_self_clean is not None
+        assert self.device._pending_self_clean[0] is True
+
+    def test_set_self_clean_does_not_update_when_send_fails(self) -> None:
+        """Test a failed self-clean command does not publish the requested state."""
+        updates: list[dict[str, bool]] = []
+        self.device.register_update(updates.append)
+
+        with (
+            patch.object(
+                self.device,
+                "build_send",
+                side_effect=OSError("send failed"),
+            ),
+            pytest.raises(OSError, match="send failed"),
+        ):
+            self.device.set_attribute(DeviceAttributes.self_clean, True)
+
+        assert self.device.attributes[DeviceAttributes.self_clean] is False
+        assert updates == []
+        assert self.device._pending_self_clean is None
+
     def test_invalid_customize_format(self) -> None:
         """Test invalid customize format."""
         self.device.set_customize("{")

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -16,6 +16,7 @@ from midealocal.devices.ac.message import (
     MessageGroupZeroQuery,
     MessageHumidityQuery,
     MessageNewProtocolQuery,
+    MessageNewProtocolSelfCleanQuery,
     MessagePowerQuery,
     MessageQuery,
     MessageSubProtocolFreshAirSet,
@@ -279,17 +280,18 @@ class TestMideaACDevice:
 
         self.device._used_subprotocol = False
         queries = self.device.build_query()
-        assert len(queries) == 10
+        assert len(queries) == 11
         assert isinstance(queries[0], MessageQuery)
         assert isinstance(queries[1], MessageNewProtocolQuery)
-        assert isinstance(queries[2], MessagePowerQuery)
-        assert isinstance(queries[3], MessageHumidityQuery)
-        assert isinstance(queries[4], MessageGroupZeroQuery)
-        assert isinstance(queries[5], MessageGroupOneQuery)
-        assert isinstance(queries[6], MessageGroupTwoQuery)
-        assert isinstance(queries[7], MessageGroupSevenQuery)
-        assert isinstance(queries[8], MessageCapabilitiesQuery)
-        assert isinstance(queries[9], MessageCapabilitiesAdditionalQuery)
+        assert isinstance(queries[2], MessageNewProtocolSelfCleanQuery)
+        assert isinstance(queries[3], MessagePowerQuery)
+        assert isinstance(queries[4], MessageHumidityQuery)
+        assert isinstance(queries[5], MessageGroupZeroQuery)
+        assert isinstance(queries[6], MessageGroupOneQuery)
+        assert isinstance(queries[7], MessageGroupTwoQuery)
+        assert isinstance(queries[8], MessageGroupSevenQuery)
+        assert isinstance(queries[9], MessageCapabilitiesQuery)
+        assert isinstance(queries[10], MessageCapabilitiesAdditionalQuery)
 
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
         """Test verified BB model starts with independent BB queries."""

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -874,7 +874,7 @@ class TestMideaACDevice:
             assert self.device._pending_self_clean is None
 
     def test_self_clean_accepts_status_at_refresh_interval_boundary(self) -> None:
-        """Test stale-status guard expires exactly at the configured refresh interval."""
+        """Test stale-status guard expires exactly at the refresh interval."""
         with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
             mock_message = mock_message_response.return_value
             mock_message.used_subprotocol = False

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -18,6 +18,7 @@ from midealocal.devices.ac.message import (
     MessageGroupZeroQuery,
     MessageHumidityQuery,
     MessageNewProtocolQuery,
+    MessageNewProtocolSelfCleanQuery,
     MessageNewProtocolSet,
     MessagePowerQuery,
     MessageQuery,
@@ -264,7 +265,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0D,
+                0x0C,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -289,8 +290,19 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.buzzer_all >> 8,
                 NewProtocolQuery.error_code_query & 0xFF,
                 NewProtocolQuery.error_code_query >> 8,
-                NewProtocolTags.b5_self_clean_active & 0xFF,
-                NewProtocolTags.b5_self_clean_active >> 8,
+            ],
+        )
+        assert msg.body[:-2] == expected_body
+
+    def test_new_protocol_self_clean_query_body(self) -> None:
+        """Test new protocol self-clean query body."""
+        msg = MessageNewProtocolSelfCleanQuery(protocol_version=ProtocolVersion.V1)
+        expected_body = bytearray(
+            [
+                0xB1,
+                0x01,
+                NewProtocolTags.self_clean & 0xFF,
+                NewProtocolTags.self_clean >> 8,
             ],
         )
         assert msg.body[:-2] == expected_body
@@ -979,37 +991,52 @@ class TestMessageACResponse:
         assert response.out_silent is expected
 
     @pytest.mark.parametrize(
-        ("byte13", "expected"),
-        [(0x40, True), (0x00, False)],
+        ("raw_value", "expected"),
+        [(0x01, True), (0x00, False)],
     )
-    def test_message_notify2_b5_self_clean_active(
+    def test_message_query_b1_self_clean_active(
         self,
-        byte13: int,
+        raw_value: int,
         expected: bool,
     ) -> None:
-        """Test Message parse notify2 B5 with self_clean_active."""
-        # B5 push body: body_type(1) + count(1) + tag(2) + length(1) + value(39)
-        payload = bytearray(39)
-        # Byte 12 changes independently of self-clean. The PortaSplit reports
-        # the active-state flag at byte 13, where 0x40 means active.
-        payload[12] = 0x3C
-        payload[13] = byte13
-        body = bytearray(2)
-        body[0] = 0xB5  # Body type
-        body[1] = 0x01  # Params count
-        body += bytearray(
+        """Test Message parse query B1 reports live self-clean state."""
+        # B1 body: body_type(1) + count(1) + tag(2) + 0x00 + length(1) + value(1)
+        self.header[9] = 0x03
+        body = bytearray(
             [
-                NewProtocolTags.b5_self_clean_active & 0xFF,  # tag low 0xE2
-                NewProtocolTags.b5_self_clean_active >> 8,  # tag high 0x00
-                len(payload),  # length 39
+                0xB1,  # Body type
+                0x01,  # Params count
+                NewProtocolTags.self_clean & 0xFF,
+                NewProtocolTags.self_clean >> 8,
+                0x00,
+                0x01,  # Value length
+                raw_value,
+                0x00,  # trailing checksum byte (stripped by MessageResponse)
             ],
         )
-        body += payload
-        body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
 
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "self_clean_active")
         assert response.self_clean_active is expected
+
+    def test_message_notify2_b5_self_clean_is_capability_only(self) -> None:
+        """Test that tag 0x0039 in a B5 body is not read as live state."""
+        # B5 advertises self-clean support with a constant 0x01, so it must not
+        # be mistaken for the running state.
+        body = bytearray(
+            [
+                0xB5,  # Body type
+                0x01,  # Params count
+                NewProtocolTags.self_clean & 0xFF,
+                NewProtocolTags.self_clean >> 8,
+                0x01,  # Value length
+                0x01,  # Capability: supported
+                0x00,  # trailing checksum byte (stripped by MessageResponse)
+            ],
+        )
+
+        response = MessageACResponse(self.header + body)
+        assert not hasattr(response, "self_clean_active")
 
     def test_message_query_c0(self) -> None:
         """Test Message parse query C0."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -979,18 +979,21 @@ class TestMessageACResponse:
         assert response.out_silent is expected
 
     @pytest.mark.parametrize(
-        ("byte12", "expected"),
-        [(0x3C, True), (0x00, False)],
+        ("byte13", "expected"),
+        [(0x40, True), (0x00, False)],
     )
     def test_message_notify2_b5_self_clean_active(
         self,
-        byte12: int,
+        byte13: int,
         expected: bool,
     ) -> None:
         """Test Message parse notify2 B5 with self_clean_active."""
         # B5 push body: body_type(1) + count(1) + tag(2) + length(1) + value(39)
         payload = bytearray(39)
-        payload[12] = byte12
+        # Byte 12 changes independently of self-clean. The PortaSplit reports
+        # the active-state flag at byte 13, where 0x40 means active.
+        payload[12] = 0x3C
+        payload[13] = byte13
         body = bytearray(2)
         body[0] = 0xB5  # Body type
         body[1] = 0x01  # Params count


### PR DESCRIPTION
## Summary

Fixes incorrect Self Clean status reporting for PortaSplit subtype 524.

`0x00E2` is a 39-byte status payload. The previous decoder treated byte 12 as
a boolean, but live captures show it remains non-zero when no self-clean cycle
is running. The actual running flag is byte 13, bit `0x40`.

This also change handles delayed status responses after a Self Clean command:

- Publish the requested switch state after the command is sent successfully.
- Ignore contradictory `0x00E2` reports until the device confirms the requested
  state or one configured refresh interval expires.
- Once confirmed, accept later status changes normally, including cycle completion.

## Validation

- Live-tested against a PortaSplit 

Fixes wuwentao/midea_ac_lan#971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated self-clean status querying for supported air conditioners.
  * Self-clean commands now provide immediate state updates while awaiting confirmation.

* **Bug Fixes**
  * Prevented outdated self-clean responses from overwriting current pending states.
  * Added timeout handling to refresh self-clean status when confirmation is delayed.
  * Failed self-clean commands no longer incorrectly change the reported state.

* **Tests**
  * Expanded coverage for self-clean queries, command success and failure, delayed responses, and capability reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->