### PR TITLE
fix(e2): encode subtype 255 temperature literally

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -83,6 +83,12 @@ class DeviceAttributes(StrEnum):
     rate = "rate"
 
 
+# E2 subtype 255 devices use literal Celsius values in the target-temperature
+# command.  Other E2 variants use the legacy half-degree wire representation
+# unless ``precision_halves`` is explicitly enabled.
+_LITERAL_TEMPERATURE_SUBTYPES = frozenset({255})
+
+
 class MideaE2Device(MideaDevice):
     """Midea E2 device."""
 
@@ -218,8 +224,12 @@ class MideaE2Device(MideaDevice):
             DeviceAttributes.current_temperature,
         ]:
             old_protocol = self._normalize_old_protocol(self._old_protocol)
-            if attr == DeviceAttributes.target_temperature:
-                value = value if self._precision_halves else value * 2
+            if (
+                attr == DeviceAttributes.target_temperature
+                and not self._precision_halves
+                and self.subtype not in _LITERAL_TEMPERATURE_SUBTYPES
+            ):
+                value = value * 2
             if attr == DeviceAttributes.power:
                 message = MessagePower(self._message_protocol_version)
                 message.power = bool(value)

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -206,6 +206,19 @@ class TestMideaE2Device:
         assert isinstance(message, MessageSet)
         assert message.target_temperature == 40
 
+    def test_set_attribute_literal_temperature_for_subtype_255(
+        self,
+    ) -> None:
+        """Subtype 255 sends literal Celsius values on the wire."""
+        device = self._device(subtype=255)
+        with patch.object(device, "build_send") as mock_build_send:
+            device.set_attribute(DeviceAttributes.target_temperature.value, 45)
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+        assert isinstance(message, MessageNewProtocolSet)
+        assert message.target_temperature == 45
+        assert message._body == bytearray([0x07, 45])
+
     def test_set_attribute_new_protocol(self) -> None:
         """Test new protocol attributes use the new protocol set message."""
         device = self._device('{"old_protocol": "false"}')


### PR DESCRIPTION
Hello!

I noticed an issue with my Midea boiler where I couldn't set the target temperature. It would always try to set it to max temp and then reset back to previous value. I've found the cause and prepared a fix for it.

I have a Midea E2 devices with `subtype=255`.

These devices expect the temperature as a literal Celsius value, while the existing default path multiplied it by `2` for the legacy half-degree representation. As a result, commands such as `45°C` were sent as `90`, rejected by the device, and reverted on the next state update.

For `subtype=255`, the fix now sends the literal value while preserving the existing behavior for other E2 variants and for `precision_halves`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected target-temperature handling for E2 subtype 255 devices.
  * Subtype 255 devices now receive literal Celsius values, including when half-degree precision is disabled.

* **Tests**
  * Added regression coverage to verify the expected serialized temperature command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->