### PR TITLE
fix(cli): namespace guard to get_sn attr

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -97,7 +97,7 @@ class MideaCLI:
         # Dump only basic device info from the base class
         _LOGGER.info("Found %d devices.", len(devices))
         # get sn
-        if self.namespace.__contains__("get_sn") and self.namespace.get_sn:
+        if getattr(self.namespace, "get_sn", False):
             _LOGGER.info("Found devices: %s", devices)
             return device_list
         for device in devices.values():

--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -97,7 +97,7 @@ class MideaCLI:
         # Dump only basic device info from the base class
         _LOGGER.info("Found %d devices.", len(devices))
         # get sn
-        if self.namespace.get_sn:
+        if self.namespace.__contains__("get_sn") and self.namespace.get_sn:
             _LOGGER.info("Found devices: %s", devices)
             return device_list
         for device in devices.values():


### PR DESCRIPTION
When running cli with setattr, discover was called without get_sn attr inside namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `discover` command’s handling of optional configuration values, preventing errors when the value is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->