### PR TITLE
feat(ed): support subtype 395 tea bar appliances

### DIFF
--- a/midealocal/devices/ed/__init__.py
+++ b/midealocal/devices/ed/__init__.py
@@ -9,6 +9,7 @@ from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 from midealocal.message import ListTypes
 
 from .message import (
+    TEA_BAR_SUBTYPE,
     MessageEDResponse,
     MessageNewSet,
     MessageOldSet,
@@ -25,6 +26,13 @@ from .message import (
 
 _LOGGER = logging.getLogger(__name__)
 
+TEA_BAR_MIN_TARGET_TEMPERATURE = 40
+TEA_BAR_MAX_TARGET_TEMPERATURE = 100
+TEA_BAR_DEFAULT_TARGET_TEMPERATURE = 100
+TEA_BAR_MIN_KEEP_WARM_HOURS = 1.0
+TEA_BAR_MAX_KEEP_WARM_HOURS = 12.0
+TEA_BAR_MODEL = "63000622"
+
 
 class DeviceAttributes(StrEnum):
     """Midea ED device attributes."""
@@ -40,6 +48,23 @@ class DeviceAttributes(StrEnum):
     life2 = "life2"
     life3 = "life3"
     child_lock = "child_lock"
+    current_temperature = "current_temperature"
+    target_temperature = "target_temperature"
+    heating = "heating"
+    dispensing = "dispensing"
+    boil_temperature = "boil_temperature"
+    boiling = "boiling"
+    keep_warm = "keep_warm"
+    keep_warm_time = "keep_warm_time"
+    keep_warm_remaining = "keep_warm_remaining"
+    sleep = "sleep"
+    screen_display = "screen_display"
+    cooling = "cooling"
+    lack_water = "lack_water"
+    standby = "standby"
+    hot_water_dispensing = "hot_water_dispensing"
+    fault_code = "fault_code"
+    fault = "fault"
     # Soft water machine (water softener) attributes
     velocity = "velocity"
     soft_available = "soft_available"
@@ -117,6 +142,28 @@ class MideaEDDevice(MideaDevice):
                 DeviceAttributes.error: None,
             },
         )
+        if self.subtype == TEA_BAR_SUBTYPE:
+            self._attributes.update(
+                {
+                    DeviceAttributes.current_temperature: None,
+                    DeviceAttributes.target_temperature: None,
+                    DeviceAttributes.heating: False,
+                    DeviceAttributes.dispensing: False,
+                    DeviceAttributes.boil_temperature: None,
+                    DeviceAttributes.boiling: False,
+                    DeviceAttributes.keep_warm: False,
+                    DeviceAttributes.keep_warm_time: None,
+                    DeviceAttributes.keep_warm_remaining: None,
+                    DeviceAttributes.sleep: False,
+                    DeviceAttributes.screen_display: True,
+                    DeviceAttributes.cooling: False,
+                    DeviceAttributes.lack_water: False,
+                    DeviceAttributes.standby: False,
+                    DeviceAttributes.hot_water_dispensing: False,
+                    DeviceAttributes.fault_code: 0,
+                    DeviceAttributes.fault: False,
+                },
+            )
         self._device_class = ListTypes.X00
 
     def _use_new_set(self) -> bool:
@@ -149,7 +196,7 @@ class MideaEDDevice(MideaDevice):
                 MessageQuery04,
             ),
             **dict.fromkeys([316, 318, 319, 320], MessageQuery05),
-            **dict.fromkeys([290, 331, 332, 340], MessageQuery06),
+            **dict.fromkeys([290, 331, 332, 340, TEA_BAR_SUBTYPE], MessageQuery06),
             **dict.fromkeys([288, 307, 329, 349], MessageQuery07),
             # Soft water machine (water softener) subtypes
             # subtype 703: model 6360000A, confirmed from cloud API modelNumber
@@ -171,7 +218,7 @@ class MideaEDDevice(MideaDevice):
 
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Midea ED device process message."""
-        message = MessageEDResponse(msg)
+        message = MessageEDResponse(msg, self.subtype)
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         if hasattr(message, "device_class"):
@@ -180,10 +227,146 @@ class MideaEDDevice(MideaDevice):
             if hasattr(message, str(status)):
                 new_status[str(status)] = getattr(message, str(status))
                 self._attributes[status] = getattr(message, str(status))
+        if self.subtype == TEA_BAR_SUBTYPE:
+            if DeviceAttributes.target_temperature in new_status:
+                target_temperature = new_status[DeviceAttributes.target_temperature]
+                new_status[DeviceAttributes.boil_temperature] = target_temperature
+                self._attributes[DeviceAttributes.boil_temperature] = target_temperature
+            if DeviceAttributes.heating in new_status:
+                heating = new_status[DeviceAttributes.heating]
+                new_status[DeviceAttributes.boiling] = heating
+                self._attributes[DeviceAttributes.boiling] = heating
         return new_status
+
+    def _set_tea_bar_attribute(
+        self,
+        attr: str,
+        value: bool | float | str,
+    ) -> bool:
+        """Build and send a subtype-395 tea bar control command."""
+        if (
+            self.subtype != TEA_BAR_SUBTYPE
+            or self.model != TEA_BAR_MODEL
+            or attr
+            not in [
+                DeviceAttributes.boil_temperature,
+                DeviceAttributes.boiling,
+                DeviceAttributes.child_lock,
+                DeviceAttributes.keep_warm,
+                DeviceAttributes.keep_warm_time,
+                DeviceAttributes.sleep,
+                DeviceAttributes.screen_display,
+                DeviceAttributes.cooling,
+            ]
+        ):
+            return False
+
+        message = MessageNewSet(self._message_protocol_version)
+        stored_value: bool | float | str
+        if attr == DeviceAttributes.boil_temperature:
+            target_temperature = int(value)
+            if not (
+                TEA_BAR_MIN_TARGET_TEMPERATURE
+                <= target_temperature
+                <= TEA_BAR_MAX_TARGET_TEMPERATURE
+            ):
+                msg = (
+                    "Tea bar target temperature must be between "
+                    f"{TEA_BAR_MIN_TARGET_TEMPERATURE} and "
+                    f"{TEA_BAR_MAX_TARGET_TEMPERATURE}"
+                )
+                raise ValueError(msg)
+            self._validate_tea_bar_target(target_temperature)
+            message.target_temperature = target_temperature
+            message.heating = True
+            stored_value = target_temperature
+        elif attr == DeviceAttributes.boiling:
+            boiling = bool(value)
+            # Model 63000622's official App TeaHeat control always sends both
+            # custom_temperature_1=100 and the heat_start toggle. It does not
+            # use the generic ED heat (0x0400) field.
+            message.target_temperature = TEA_BAR_DEFAULT_TARGET_TEMPERATURE
+            message.heating = boiling
+            stored_value = boiling
+        elif attr == DeviceAttributes.child_lock:
+            # Model 63000622's official Lua lock control is
+            # setbytes(0x01, 0x02, 0x01/0x00, 0x00, 0x00).
+            child_lock = bool(value)
+            message.lock = child_lock
+            stored_value = child_lock
+        elif attr == DeviceAttributes.sleep:
+            sleep = bool(value)
+            message.sleep = sleep
+            stored_value = sleep
+        elif attr == DeviceAttributes.screen_display:
+            screen_display = bool(value)
+            message.sleep = not screen_display
+            stored_value = screen_display
+        elif attr == DeviceAttributes.cooling:
+            cooling = bool(value)
+            if (
+                not cooling
+                and self._attributes.get(DeviceAttributes.dispensing) is True
+            ):
+                msg = "Tea bar cooling cannot be stopped while dispensing water"
+                raise ValueError(msg)
+            message.cooling = cooling
+            stored_value = cooling
+        else:
+            keep_warm = (
+                bool(value)
+                if attr == DeviceAttributes.keep_warm
+                else bool(self._attributes.get(DeviceAttributes.keep_warm))
+            )
+            keep_warm_time = (
+                float(value)
+                if attr == DeviceAttributes.keep_warm_time
+                else self._attributes.get(DeviceAttributes.keep_warm_time)
+            )
+            raw_keep_warm_time = 0
+            if isinstance(keep_warm_time, int | float):
+                if not (
+                    TEA_BAR_MIN_KEEP_WARM_HOURS
+                    <= keep_warm_time
+                    <= TEA_BAR_MAX_KEEP_WARM_HOURS
+                    and (float(keep_warm_time) * 2).is_integer()
+                ):
+                    msg = (
+                        "Tea bar keep-warm time must be between "
+                        f"{TEA_BAR_MIN_KEEP_WARM_HOURS:g} and "
+                        f"{TEA_BAR_MAX_KEEP_WARM_HOURS:g} hours in 0.5-hour steps"
+                    )
+                    raise ValueError(msg)
+                raw_keep_warm_time = int(keep_warm_time * 2)
+            message.keep_warm = keep_warm
+            message.keep_warm_time = raw_keep_warm_time
+            stored_value = (
+                keep_warm if attr == DeviceAttributes.keep_warm else float(value)
+            )
+
+        self._attributes[attr] = stored_value
+        self.build_send(message)
+        return True
+
+    def _validate_tea_bar_target(self, target_temperature: int) -> None:
+        """Reject a target that cannot increase the current temperature."""
+        current_temperature = self._attributes.get(
+            DeviceAttributes.current_temperature,
+        )
+        if (
+            isinstance(current_temperature, int | float)
+            and current_temperature >= target_temperature
+        ):
+            msg = (
+                f"Tea bar current temperature {current_temperature} is not "
+                f"below target temperature {target_temperature}"
+            )
+            raise ValueError(msg)
 
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea ED device set attribute."""
+        if self._set_tea_bar_attribute(attr, value):
+            return
         message: MessageNewSet | MessageOldSet | None = None
         if self._use_new_set():
             if attr in [

--- a/midealocal/devices/ed/__init__.py
+++ b/midealocal/devices/ed/__init__.py
@@ -143,7 +143,7 @@ class MideaEDDevice(MideaDevice):
                 DeviceAttributes.error: None,
             },
         )
-        if self.subtype == TEA_BAR_SUBTYPE:
+        if self._is_tea_bar():
             self._attributes.update(
                 {
                     DeviceAttributes.current_temperature: None,
@@ -171,6 +171,10 @@ class MideaEDDevice(MideaDevice):
         # if (self.sub_type > 342 or self.sub_type == 340) else False
         return True
 
+    def _is_tea_bar(self) -> bool:
+        """Return whether this device matches the verified tea-bar model."""
+        return self.subtype == TEA_BAR_SUBTYPE and self.model == TEA_BAR_MODEL
+
     def build_query(
         self,
     ) -> list[
@@ -197,7 +201,7 @@ class MideaEDDevice(MideaDevice):
                 MessageQuery04,
             ),
             **dict.fromkeys([316, 318, 319, 320], MessageQuery05),
-            **dict.fromkeys([290, 331, 332, 340, TEA_BAR_SUBTYPE], MessageQuery06),
+            **dict.fromkeys([290, 331, 332, 340], MessageQuery06),
             **dict.fromkeys([288, 307, 329, 349], MessageQuery07),
             # Soft water machine (water softener) subtypes
             # subtype 703: model 6360000A, confirmed from cloud API modelNumber
@@ -208,6 +212,8 @@ class MideaEDDevice(MideaDevice):
             # remove MessageQuery03 as it return 0
             775: MessageQuery01,
         }
+        if self._is_tea_bar():
+            return [MessageQuery06(pv)]
         query_cls = subtype_query.get(self.subtype)
         if query_cls is not None:
             return [query_cls(pv)]
@@ -219,7 +225,8 @@ class MideaEDDevice(MideaDevice):
 
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Midea ED device process message."""
-        message = MessageEDResponse(msg, self.subtype)
+        response_subtype = self.subtype if self._is_tea_bar() else 0
+        message = MessageEDResponse(msg, response_subtype)
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         if hasattr(message, "device_class"):
@@ -228,7 +235,7 @@ class MideaEDDevice(MideaDevice):
             if hasattr(message, str(status)):
                 new_status[str(status)] = getattr(message, str(status))
                 self._attributes[status] = getattr(message, str(status))
-        if self.subtype == TEA_BAR_SUBTYPE:
+        if self._is_tea_bar():
             if DeviceAttributes.target_temperature in new_status:
                 target_temperature = new_status[DeviceAttributes.target_temperature]
                 new_status[DeviceAttributes.boil_temperature] = target_temperature
@@ -245,26 +252,24 @@ class MideaEDDevice(MideaDevice):
         value: bool | float | str,
     ) -> bool:
         """Build and send a subtype-395 tea bar control command."""
-        if (
-            self.subtype != TEA_BAR_SUBTYPE
-            or self.model != TEA_BAR_MODEL
-            or attr
-            not in [
-                DeviceAttributes.boil_temperature,
-                DeviceAttributes.boiling,
-                DeviceAttributes.child_lock,
-                DeviceAttributes.keep_warm,
-                DeviceAttributes.keep_warm_time,
-                DeviceAttributes.sleep,
-                DeviceAttributes.screen_display,
-                DeviceAttributes.cooling,
-            ]
-        ):
+        if not self._is_tea_bar() or attr not in [
+            DeviceAttributes.boil_temperature,
+            DeviceAttributes.boiling,
+            DeviceAttributes.child_lock,
+            DeviceAttributes.keep_warm,
+            DeviceAttributes.keep_warm_time,
+            DeviceAttributes.sleep,
+            DeviceAttributes.screen_display,
+            DeviceAttributes.cooling,
+        ]:
             return False
 
         message = MessageNewSet(self._message_protocol_version)
         stored_value: bool | float | str
         if attr == DeviceAttributes.boil_temperature:
+            if isinstance(value, float) and not value.is_integer():
+                msg = "Tea bar target temperature must be a whole number"
+                raise ValueError(msg)
             target_temperature = int(value)
             if not (
                 TEA_BAR_MIN_TARGET_TEMPERATURE

--- a/midealocal/devices/ed/__init__.py
+++ b/midealocal/devices/ed/__init__.py
@@ -31,6 +31,7 @@ TEA_BAR_MAX_TARGET_TEMPERATURE = 100
 TEA_BAR_DEFAULT_TARGET_TEMPERATURE = 100
 TEA_BAR_MIN_KEEP_WARM_HOURS = 1.0
 TEA_BAR_MAX_KEEP_WARM_HOURS = 12.0
+TEA_BAR_DEFAULT_KEEP_WARM_HOURS = 12.0
 TEA_BAR_MODEL = "63000622"
 
 
@@ -323,8 +324,16 @@ class MideaEDDevice(MideaDevice):
                 if attr == DeviceAttributes.keep_warm_time
                 else self._attributes.get(DeviceAttributes.keep_warm_time)
             )
+            # A zero addition means "use the appliance default" for model
+            # 63000622. The appliance has no user-adjustable keep-warm duration
+            # and defaults to 12 hours, so normal keep-warm toggles must not
+            # invent or require a duration. Keep explicit non-default values
+            # only for low-level backward compatibility.
             raw_keep_warm_time = 0
-            if isinstance(keep_warm_time, int | float):
+            if (
+                isinstance(keep_warm_time, int | float)
+                and float(keep_warm_time) != TEA_BAR_DEFAULT_KEEP_WARM_HOURS
+            ):
                 if not (
                     TEA_BAR_MIN_KEEP_WARM_HOURS
                     <= keep_warm_time

--- a/midealocal/devices/ed/message.py
+++ b/midealocal/devices/ed/message.py
@@ -85,7 +85,7 @@ class NewSetTags(IntEnum):
     tea_bar_target_temperature = 0x0401
     tea_bar_heat_start = 0x0405
     tea_bar_keep_warm = 0x0408
-    tea_bar_sleep = 0x0104
+    tea_bar_sleep = 0x0104  # Intentional alias: same wire tag as salt_setting.
     tea_bar_cooling = 0x0500
 
 

--- a/midealocal/devices/ed/message.py
+++ b/midealocal/devices/ed/message.py
@@ -11,6 +11,26 @@ from midealocal.message import (
     MessageType,
 )
 
+TEA_BAR_SUBTYPE = 395
+TEA_BAR_CURRENT_TEMPERATURE_OFFSET = 3
+TEA_BAR_TARGET_TEMPERATURE_OFFSET = 10
+TEA_BAR_HEATING_FLAG_OFFSET = 49
+TEA_BAR_STATUS_FLAG_OFFSET = 51
+TEA_BAR_KEEP_WARM_TIME_OFFSET = 33
+TEA_BAR_KEEP_WARM_REMAINING_LOW_OFFSET = 34
+TEA_BAR_KEEP_WARM_REMAINING_HIGH_OFFSET = 35
+TEA_BAR_KEEP_WARM_FLAG_OFFSET = 48
+TEA_BAR_COOLING_STATUS_OFFSET = 50
+TEA_BAR_HEATING_FLAG = 0x01
+TEA_BAR_KEEP_WARM_FLAG = 0x01
+TEA_BAR_SLEEP_FLAG = 0x80
+TEA_BAR_STATUS_LACK_WATER_FLAG = 0x02
+TEA_BAR_STATUS_HEATING_FLAG = 0x04
+TEA_BAR_STATUS_HOT_WATER_FLAG = 0x40
+TEA_BAR_STATUS_STANDBY_FLAG = 0x80
+TEA_BAR_STATUS_DISPENSING_MASK = 0x50
+TEA_BAR_ERROR_OFFSET = 52
+
 
 class Attributes(IntEnum):
     """Attributes."""
@@ -62,6 +82,11 @@ class NewSetTags(IntEnum):
     cl_sterilization = 0x0109  # setbytes(0x09, 0x01, ...)
     leak_water_protection = 0x010A  # setbytes(0x0A, 0x01, ...)
     water_way = 0x0200  # setbytes(0x00, 0x02, ...)
+    tea_bar_target_temperature = 0x0401
+    tea_bar_heat_start = 0x0405
+    tea_bar_keep_warm = 0x0408
+    tea_bar_sleep = 0x0104
+    tea_bar_cooling = 0x0500
 
 
 class EDNewSetParamPack:
@@ -305,6 +330,13 @@ class MessageNewSet(MessageEDBase):
         self.leak_water_protection: bool | None = None
         self.leak_water_protection_value: int | None = None
         self.water_way: bool | None = None
+        # Tea bar controls from the official ED Lua encoder.
+        self.target_temperature: int | None = None
+        self.heating: bool | None = None
+        self.keep_warm: bool | None = None
+        self.keep_warm_time: int | None = None
+        self.sleep: bool | None = None
+        self.cooling: bool | None = None
 
     @property
     def _body(self) -> bytearray:
@@ -423,6 +455,48 @@ class MessageNewSet(MessageEDBase):
                     value=0x01 if self.water_way else 0x00,
                 ),
             )
+        if self.target_temperature is not None:
+            pack_count += 1
+            payload.extend(
+                EDNewSetParamPack.pack(
+                    param=NewSetTags.tea_bar_target_temperature,
+                    value=self.target_temperature,
+                    addition=0x0A,
+                ),
+            )
+        if self.heating is not None:
+            pack_count += 1
+            payload.extend(
+                EDNewSetParamPack.pack(
+                    param=NewSetTags.tea_bar_heat_start,
+                    value=0x01 if self.heating else 0x00,
+                ),
+            )
+        if self.keep_warm is not None:
+            pack_count += 1
+            payload.extend(
+                EDNewSetParamPack.pack(
+                    param=NewSetTags.tea_bar_keep_warm,
+                    value=0x01 if self.keep_warm else 0x00,
+                    addition=self.keep_warm_time or 0,
+                ),
+            )
+        if self.sleep is not None:
+            pack_count += 1
+            payload.extend(
+                EDNewSetParamPack.pack(
+                    param=NewSetTags.tea_bar_sleep,
+                    value=0x01 if self.sleep else 0x00,
+                ),
+            )
+        if self.cooling is not None:
+            pack_count += 1
+            payload.extend(
+                EDNewSetParamPack.pack(
+                    param=NewSetTags.tea_bar_cooling,
+                    value=0x01 if self.cooling else 0x00,
+                ),
+            )
         payload[1] = pack_count
         return payload
 
@@ -496,12 +570,45 @@ class EDMessageBody05(MessageBody):
 class EDMessageBody06(MessageBody):
     """ED message body 06."""
 
-    def __init__(self, body: bytearray) -> None:
+    def __init__(self, body: bytearray, subtype: int = 0) -> None:
         """Initialize ED message body 06."""
         super().__init__(body)
         self.power = (body[51] & 0x01) > 0
         self.child_lock = (body[51] & 0x08) > 0
         self.water_consumption = body[25] + (body[26] << 8)
+        if subtype == TEA_BAR_SUBTYPE:
+            self.current_temperature = body[TEA_BAR_CURRENT_TEMPERATURE_OFFSET]
+            self.target_temperature = body[TEA_BAR_TARGET_TEMPERATURE_OFFSET] or None
+            self.heating = (
+                body[TEA_BAR_HEATING_FLAG_OFFSET] == TEA_BAR_HEATING_FLAG
+                and body[TEA_BAR_STATUS_FLAG_OFFSET] & TEA_BAR_STATUS_HEATING_FLAG > 0
+            )
+            self.dispensing = (
+                body[TEA_BAR_STATUS_FLAG_OFFSET] & TEA_BAR_STATUS_DISPENSING_MASK
+                == TEA_BAR_STATUS_DISPENSING_MASK
+            )
+            self.keep_warm = (
+                body[TEA_BAR_KEEP_WARM_FLAG_OFFSET] & TEA_BAR_KEEP_WARM_FLAG > 0
+            )
+            self.sleep = body[TEA_BAR_KEEP_WARM_FLAG_OFFSET] & TEA_BAR_SLEEP_FLAG > 0
+            self.screen_display = not self.sleep
+            self.cooling = body[TEA_BAR_COOLING_STATUS_OFFSET] != 0
+            self.lack_water = (
+                body[TEA_BAR_STATUS_FLAG_OFFSET] & TEA_BAR_STATUS_LACK_WATER_FLAG > 0
+            )
+            self.standby = (
+                body[TEA_BAR_STATUS_FLAG_OFFSET] & TEA_BAR_STATUS_STANDBY_FLAG > 0
+            )
+            self.hot_water_dispensing = (
+                body[TEA_BAR_STATUS_FLAG_OFFSET] & TEA_BAR_STATUS_HOT_WATER_FLAG > 0
+            )
+            self.fault_code = body[TEA_BAR_ERROR_OFFSET]
+            self.fault = self.fault_code != 0
+            raw_keep_warm_time = body[TEA_BAR_KEEP_WARM_TIME_OFFSET]
+            self.keep_warm_time = raw_keep_warm_time / 2 if raw_keep_warm_time else None
+            self.keep_warm_remaining = body[TEA_BAR_KEEP_WARM_REMAINING_LOW_OFFSET] + (
+                body[TEA_BAR_KEEP_WARM_REMAINING_HIGH_OFFSET] << 8
+            )
 
 
 class EDMessageBody07(MessageBody):
@@ -637,7 +744,7 @@ class EDMessageBodyFF(MessageBody):
 class MessageEDResponse(MessageResponse):
     """ED message response."""
 
-    def __init__(self, message: bytes) -> None:
+    def __init__(self, message: bytes, subtype: int = 0) -> None:
         """Initialize ED message response."""
         super().__init__(bytearray(message))
         if self._message_type in [
@@ -646,16 +753,22 @@ class MessageEDResponse(MessageResponse):
             MessageType.notify1,
         ]:
             self.device_class = self._body_type
-            if self._body_type in [ListTypes.X00, ListTypes.X15, ListTypes.FF]:
+            if self._body_type in [ListTypes.X00, ListTypes.FF]:
                 self.set_body(EDMessageBodyFF(super().body))
-            if self.body_type == ListTypes.X01:
+            elif self._body_type == ListTypes.X15 and subtype == TEA_BAR_SUBTYPE:
+                # Subtype 395 acknowledges a new-set command with the same status
+                # payload as body 06, but omits the leading 0x06 body type byte.
+                status_body = bytearray(super().body)
+                status_body[0] = ListTypes.X06
+                self.set_body(EDMessageBody06(status_body, subtype))
+            elif self.body_type == ListTypes.X01:
                 self.set_body(EDMessageBody01(super().body))
             elif self.body_type in [ListTypes.X03, ListTypes.X04]:
                 self.set_body(EDMessageBody03(super().body))
             elif self.body_type == ListTypes.X05:
                 self.set_body(EDMessageBody05(super().body))
             elif self.body_type == ListTypes.X06:
-                self.set_body(EDMessageBody06(super().body))
+                self.set_body(EDMessageBody06(super().body, subtype))
             elif self.body_type == ListTypes.X07:
                 self.set_body(EDMessageBody07(super().body))
             elif self.body_type == ListTypes.X09:

--- a/midealocal/devices/ed/message.py
+++ b/midealocal/devices/ed/message.py
@@ -756,11 +756,13 @@ class MessageEDResponse(MessageResponse):
             if self._body_type in [ListTypes.X00, ListTypes.FF]:
                 self.set_body(EDMessageBodyFF(super().body))
             elif self._body_type == ListTypes.X15 and subtype == TEA_BAR_SUBTYPE:
-                # Subtype 395 acknowledges a new-set command with the same status
-                # payload as body 06, but omits the leading 0x06 body type byte.
+                # Subtype 395 can return either a full body-06 style status
+                # acknowledgement or a short X15 acknowledgement. Only convert
+                # the full status form because EDMessageBody06 reads body[52].
                 status_body = bytearray(super().body)
-                status_body[0] = ListTypes.X06
-                self.set_body(EDMessageBody06(status_body, subtype))
+                if len(status_body) > TEA_BAR_ERROR_OFFSET:
+                    status_body[0] = ListTypes.X06
+                    self.set_body(EDMessageBody06(status_body, subtype))
             elif self.body_type == ListTypes.X01:
                 self.set_body(EDMessageBody01(super().body))
             elif self.body_type in [ListTypes.X03, ListTypes.X04]:

--- a/tests/devices/ed/device_ed_test.py
+++ b/tests/devices/ed/device_ed_test.py
@@ -19,6 +19,8 @@ from midealocal.devices.ed.message import (
     MessageQueryFF,
 )
 
+TEST_AUTH_VALUE = "AA"
+
 
 class TestMideaEDDevice:
     """Test Midea ED Device."""
@@ -33,7 +35,7 @@ class TestMideaEDDevice:
             device_id=1,
             ip_address="192.168.1.100",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="test_model",
@@ -126,7 +128,7 @@ class TestMideaEDDevice:
             device_id=1,
             ip_address="192.168.1.100",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="test_model",
@@ -153,7 +155,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -195,6 +197,43 @@ class TestMideaEDDevice:
         assert DeviceAttributes.fault_code not in self.device.attributes
         assert DeviceAttributes.fault not in self.device.attributes
 
+        wrong_subtype = MideaEDDevice(
+            name="Same model, different subtype",
+            device_id=4,
+            ip_address="192.0.2.4",
+            port=6444,
+            token=TEST_AUTH_VALUE,
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=394,
+            customize="",
+        )
+        for attribute in (
+            DeviceAttributes.current_temperature,
+            DeviceAttributes.target_temperature,
+            DeviceAttributes.heating,
+            DeviceAttributes.dispensing,
+            DeviceAttributes.boil_temperature,
+            DeviceAttributes.boiling,
+            DeviceAttributes.keep_warm,
+            DeviceAttributes.keep_warm_time,
+            DeviceAttributes.keep_warm_remaining,
+            DeviceAttributes.sleep,
+            DeviceAttributes.screen_display,
+            DeviceAttributes.cooling,
+            DeviceAttributes.lack_water,
+            DeviceAttributes.standby,
+            DeviceAttributes.hot_water_dispensing,
+            DeviceAttributes.fault_code,
+            DeviceAttributes.fault,
+        ):
+            assert attribute not in wrong_subtype.attributes
+        with patch.object(wrong_subtype, "build_send") as mock_build_send:
+            wrong_subtype.set_attribute(DeviceAttributes.boil_temperature, 80)
+            wrong_subtype.set_attribute(DeviceAttributes.keep_warm, True)
+        mock_build_send.assert_not_called()
+
     def test_tea_bar_query_is_model_specific(self) -> None:
         """Use body-06 queries only for the verified subtype and model."""
         tea_bar = MideaEDDevice(
@@ -202,7 +241,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -218,7 +257,7 @@ class TestMideaEDDevice:
             device_id=3,
             ip_address="192.0.2.2",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000000",
@@ -242,7 +281,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -280,7 +319,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -305,7 +344,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -368,7 +407,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -431,7 +470,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -451,7 +490,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -475,7 +514,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -498,7 +537,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -521,7 +560,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -551,7 +590,7 @@ class TestMideaEDDevice:
             device_id=3,
             ip_address="192.0.2.2",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000000",
@@ -575,7 +614,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -599,7 +638,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -623,7 +662,7 @@ class TestMideaEDDevice:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="63000622",
@@ -652,7 +691,7 @@ class TestMideaEDDeviceSoftWater:
             device_id=2,
             ip_address="192.0.2.1",
             port=6444,
-            token="AA",
+            token=TEST_AUTH_VALUE,
             key="BB",
             device_protocol=ProtocolVersion.V3,
             model="6360000A",

--- a/tests/devices/ed/device_ed_test.py
+++ b/tests/devices/ed/device_ed_test.py
@@ -111,7 +111,6 @@ class TestMideaEDDevice:
             (309, MessageQuery04),
             (316, MessageQuery05),
             (290, MessageQuery06),
-            (395, MessageQuery06),
             (288, MessageQuery07),
             (775, MessageQuery01),
         ],
@@ -147,8 +146,8 @@ class TestMideaEDDevice:
             self.device.set_attribute(DeviceAttributes.child_lock, True)
             mock_build_send.assert_called()
 
-    def test_tea_bar_attributes_are_subtype_specific(self) -> None:
-        """Expose tea bar status attributes only for subtype 395."""
+    def test_tea_bar_attributes_are_model_specific(self) -> None:
+        """Expose tea bar status attributes only for the verified model."""
         tea_bar = MideaEDDevice(
             name="Tea Bar",
             device_id=2,
@@ -196,7 +195,47 @@ class TestMideaEDDevice:
         assert DeviceAttributes.fault_code not in self.device.attributes
         assert DeviceAttributes.fault not in self.device.attributes
 
-    def test_tea_bar_set_target_starts_heating(self) -> None:
+    def test_tea_bar_query_is_model_specific(self) -> None:
+        """Use body-06 queries only for the verified subtype and model."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        queries = tea_bar.build_query()
+        assert len(queries) == 1
+        assert isinstance(queries[0], MessageQuery06)
+
+        other_model = MideaEDDevice(
+            name="Other subtype-395 appliance",
+            device_id=3,
+            ip_address="192.0.2.2",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000000",
+            subtype=395,
+            customize="",
+        )
+        queries = other_model.build_query()
+        assert len(queries) == 3
+        assert isinstance(queries[0], MessageQuery)
+        assert DeviceAttributes.current_temperature not in other_model.attributes
+
+        with patch("midealocal.devices.ed.MessageEDResponse") as response:
+            other_model.process_message(b"")
+        response.assert_called_once_with(b"", 0)
+
+    @pytest.mark.parametrize("target", [80, 80.0])
+    def test_tea_bar_set_target_starts_heating(self, target: float) -> None:
         """Set target temperature with the official compound start command."""
         tea_bar = MideaEDDevice(
             name="Tea Bar",
@@ -213,7 +252,7 @@ class TestMideaEDDevice:
         tea_bar._attributes[DeviceAttributes.current_temperature] = 60
 
         with patch.object(tea_bar, "build_send") as mock_build_send:
-            tea_bar.set_attribute(DeviceAttributes.boil_temperature, 80)
+            tea_bar.set_attribute(DeviceAttributes.boil_temperature, target)
 
         message = mock_build_send.call_args.args[0]
         assert message.body == bytearray(
@@ -473,6 +512,29 @@ class TestMideaEDDevice:
             pytest.raises(ValueError, match="is not below target"),
         ):
             tea_bar.set_attribute(DeviceAttributes.boil_temperature, 70)
+        mock_build_send.assert_not_called()
+
+    def test_tea_bar_rejects_fractional_target_temperature(self) -> None:
+        """Reject fractional targets instead of silently truncating them."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 20
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match="must be a whole number"),
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boil_temperature, 80.5)
         mock_build_send.assert_not_called()
 
     def test_non_tea_bar_cannot_send_tea_bar_controls(self) -> None:

--- a/tests/devices/ed/device_ed_test.py
+++ b/tests/devices/ed/device_ed_test.py
@@ -111,6 +111,7 @@ class TestMideaEDDevice:
             (309, MessageQuery04),
             (316, MessageQuery05),
             (290, MessageQuery06),
+            (395, MessageQuery06),
             (288, MessageQuery07),
             (775, MessageQuery01),
         ],
@@ -146,6 +147,435 @@ class TestMideaEDDevice:
             self.device.set_attribute(DeviceAttributes.child_lock, True)
             mock_build_send.assert_called()
 
+    def test_tea_bar_attributes_are_subtype_specific(self) -> None:
+        """Expose tea bar status attributes only for subtype 395."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        assert tea_bar.attributes[DeviceAttributes.current_temperature] is None
+        assert tea_bar.attributes[DeviceAttributes.target_temperature] is None
+        assert tea_bar.attributes[DeviceAttributes.heating] is False
+        assert tea_bar.attributes[DeviceAttributes.dispensing] is False
+        assert tea_bar.attributes[DeviceAttributes.boil_temperature] is None
+        assert tea_bar.attributes[DeviceAttributes.boiling] is False
+        assert tea_bar.attributes[DeviceAttributes.keep_warm] is False
+        assert tea_bar.attributes[DeviceAttributes.keep_warm_time] is None
+        assert tea_bar.attributes[DeviceAttributes.keep_warm_remaining] is None
+        assert tea_bar.attributes[DeviceAttributes.sleep] is False
+        assert tea_bar.attributes[DeviceAttributes.screen_display] is True
+        assert tea_bar.attributes[DeviceAttributes.cooling] is False
+        assert tea_bar.attributes[DeviceAttributes.lack_water] is False
+        assert tea_bar.attributes[DeviceAttributes.standby] is False
+        assert tea_bar.attributes[DeviceAttributes.hot_water_dispensing] is False
+        assert tea_bar.attributes[DeviceAttributes.fault_code] == 0
+        assert tea_bar.attributes[DeviceAttributes.fault] is False
+        assert DeviceAttributes.current_temperature not in self.device.attributes
+        assert DeviceAttributes.target_temperature not in self.device.attributes
+        assert DeviceAttributes.heating not in self.device.attributes
+        assert DeviceAttributes.dispensing not in self.device.attributes
+        assert DeviceAttributes.boil_temperature not in self.device.attributes
+        assert DeviceAttributes.boiling not in self.device.attributes
+        assert DeviceAttributes.keep_warm not in self.device.attributes
+        assert DeviceAttributes.keep_warm_time not in self.device.attributes
+        assert DeviceAttributes.keep_warm_remaining not in self.device.attributes
+        assert DeviceAttributes.sleep not in self.device.attributes
+        assert DeviceAttributes.screen_display not in self.device.attributes
+        assert DeviceAttributes.cooling not in self.device.attributes
+        assert DeviceAttributes.lack_water not in self.device.attributes
+        assert DeviceAttributes.standby not in self.device.attributes
+        assert DeviceAttributes.hot_water_dispensing not in self.device.attributes
+        assert DeviceAttributes.fault_code not in self.device.attributes
+        assert DeviceAttributes.fault not in self.device.attributes
+
+    def test_tea_bar_set_target_starts_heating(self) -> None:
+        """Set target temperature with the official compound start command."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 60
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(DeviceAttributes.boil_temperature, 80)
+
+        message = mock_build_send.call_args.args[0]
+        assert message.body == bytearray(
+            [
+                0x15,
+                0x01,
+                0x02,
+                0x01,
+                0x04,
+                0x50,
+                0x0A,
+                0x00,
+                0x05,
+                0x04,
+                0x01,
+                0x00,
+                0x00,
+            ],
+        )
+
+    def test_tea_bar_status_updates_control_entities(self) -> None:
+        """Mirror reported target and heating state into writable controls."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        with patch("midealocal.devices.ed.MessageEDResponse") as response:
+            message = response.return_value
+            message.target_temperature = 80
+            message.heating = True
+            status = tea_bar.process_message(b"")
+
+        assert status[DeviceAttributes.boil_temperature] == 80
+        assert status[DeviceAttributes.boiling] is True
+        assert tea_bar.attributes[DeviceAttributes.boil_temperature] == 80
+        assert tea_bar.attributes[DeviceAttributes.boiling] is True
+
+    def test_tea_bar_heating_switch_uses_official_tea_heat_command(self) -> None:
+        """Use the model-specific App command for normal 100-degree boiling."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 60
+        tea_bar._attributes[DeviceAttributes.boil_temperature] = 80
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(DeviceAttributes.boiling, True)
+            start_message = mock_build_send.call_args.args[0]
+            assert start_message.body == bytearray(
+                [
+                    0x15,
+                    0x01,
+                    0x02,
+                    0x01,
+                    0x04,
+                    0x64,
+                    0x0A,
+                    0x00,
+                    0x05,
+                    0x04,
+                    0x01,
+                    0x00,
+                    0x00,
+                ],
+            )
+
+            tea_bar.set_attribute(DeviceAttributes.boiling, False)
+            stop_message = mock_build_send.call_args.args[0]
+            assert stop_message.body == bytearray(
+                [
+                    0x15,
+                    0x01,
+                    0x02,
+                    0x01,
+                    0x04,
+                    0x64,
+                    0x0A,
+                    0x00,
+                    0x05,
+                    0x04,
+                    0x00,
+                    0x00,
+                    0x00,
+                ],
+            )
+
+    @pytest.mark.parametrize(("locked", "raw_value"), [(True, 0x01), (False, 0x00)])
+    def test_tea_bar_child_lock_uses_official_lua_command(
+        self,
+        locked: bool,
+        raw_value: int,
+    ) -> None:
+        """Encode the model-specific official child-lock command."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(DeviceAttributes.child_lock, locked)
+
+        message = mock_build_send.call_args.args[0]
+        assert message.body == bytearray(
+            [0x15, 0x01, 0x01, 0x01, 0x02, raw_value, 0x00, 0x00],
+        )
+
+    @pytest.mark.parametrize(
+        ("attribute", "enabled", "expected"),
+        [
+            (
+                DeviceAttributes.sleep,
+                True,
+                [0x15, 0x01, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00],
+            ),
+            (
+                DeviceAttributes.sleep,
+                False,
+                [0x15, 0x01, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00],
+            ),
+            (
+                DeviceAttributes.screen_display,
+                True,
+                [0x15, 0x01, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00],
+            ),
+            (
+                DeviceAttributes.screen_display,
+                False,
+                [0x15, 0x01, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00],
+            ),
+            (
+                DeviceAttributes.cooling,
+                True,
+                [0x15, 0x01, 0x01, 0x00, 0x05, 0x01, 0x00, 0x00],
+            ),
+            (
+                DeviceAttributes.cooling,
+                False,
+                [0x15, 0x01, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00],
+            ),
+        ],
+    )
+    def test_tea_bar_auxiliary_controls_use_official_lua_commands(
+        self,
+        attribute: DeviceAttributes,
+        enabled: bool,
+        expected: list[int],
+    ) -> None:
+        """Encode the model-specific screen and signal-cooling controls."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(attribute, enabled)
+
+        assert mock_build_send.call_args.args[0].body == bytearray(expected)
+
+    def test_tea_bar_rejects_stopping_cooling_while_dispensing(self) -> None:
+        """Match the official App safety check for signal cooling."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.dispensing] = True
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match="cannot be stopped"),
+        ):
+            tea_bar.set_attribute(DeviceAttributes.cooling, False)
+        mock_build_send.assert_not_called()
+
+    @pytest.mark.parametrize("target", [39, 101])
+    def test_tea_bar_rejects_unsafe_target(self, target: int) -> None:
+        """Reject target temperatures outside the supported safe range."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 20
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match="must be between"),
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boil_temperature, target)
+        mock_build_send.assert_not_called()
+
+    def test_tea_bar_rejects_target_not_above_current_temperature(self) -> None:
+        """Match the official App preflight for a non-increasing target."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.current_temperature] = 70
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match="is not below target"),
+        ):
+            tea_bar.set_attribute(DeviceAttributes.boil_temperature, 70)
+        mock_build_send.assert_not_called()
+
+    def test_non_tea_bar_cannot_send_tea_bar_controls(self) -> None:
+        """Never apply tea bar controls to another ED subtype."""
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.boil_temperature, 80)
+            self.device.set_attribute(DeviceAttributes.boiling, True)
+        mock_build_send.assert_not_called()
+
+    def test_other_model_cannot_send_tea_bar_controls(self) -> None:
+        """Never apply model-specific commands by subtype alone."""
+        other_model = MideaEDDevice(
+            name="Other subtype-395 appliance",
+            device_id=3,
+            ip_address="192.0.2.2",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000000",
+            subtype=395,
+            customize="",
+        )
+
+        with patch.object(other_model, "build_send") as mock_build_send:
+            other_model.set_attribute(DeviceAttributes.boil_temperature, 80)
+            other_model.set_attribute(DeviceAttributes.boiling, True)
+            other_model.set_attribute(DeviceAttributes.keep_warm, True)
+            other_model.set_attribute(DeviceAttributes.sleep, True)
+            other_model.set_attribute(DeviceAttributes.screen_display, True)
+            other_model.set_attribute(DeviceAttributes.cooling, True)
+        mock_build_send.assert_not_called()
+
+    def test_tea_bar_keep_warm_uses_official_lua_command(self) -> None:
+        """Send the model-specific keep-warm toggle with its saved duration."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+        tea_bar._attributes[DeviceAttributes.keep_warm_time] = 3.0
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(DeviceAttributes.keep_warm, True)
+
+        message = mock_build_send.call_args.args[0]
+        assert message.body == bytearray(
+            [0x15, 0x01, 0x01, 0x08, 0x04, 0x01, 0x06, 0x00],
+        )
+
+    def test_tea_bar_keep_warm_time_preserves_off_state(self) -> None:
+        """Save a duration without unexpectedly enabling keep-warm."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+
+        with patch.object(tea_bar, "build_send") as mock_build_send:
+            tea_bar.set_attribute(DeviceAttributes.keep_warm_time, 4.5)
+
+        message = mock_build_send.call_args.args[0]
+        assert message.body == bytearray(
+            [0x15, 0x01, 0x01, 0x08, 0x04, 0x00, 0x09, 0x00],
+        )
+
+    @pytest.mark.parametrize("duration", [0.5, 12.5, 1.25])
+    def test_tea_bar_rejects_invalid_keep_warm_time(self, duration: float) -> None:
+        """Reject durations outside the official model range and step."""
+        tea_bar = MideaEDDevice(
+            name="Tea Bar",
+            device_id=2,
+            ip_address="192.0.2.1",
+            port=6444,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V3,
+            model="63000622",
+            subtype=395,
+            customize="",
+        )
+
+        with (
+            patch.object(tea_bar, "build_send") as mock_build_send,
+            pytest.raises(ValueError, match=r"0\.5-hour steps"),
+        ):
+            tea_bar.set_attribute(DeviceAttributes.keep_warm_time, duration)
+        mock_build_send.assert_not_called()
+
 
 class TestMideaEDDeviceSoftWater:
     """Test Midea ED Device soft water machine (subtype 703)."""
@@ -158,7 +588,7 @@ class TestMideaEDDeviceSoftWater:
         self.device = MideaEDDevice(
             name="Soft Water",
             device_id=2,
-            ip_address="192.168.1.101",
+            ip_address="192.0.2.1",
             port=6444,
             token="AA",
             key="BB",

--- a/tests/devices/ed/message_ed_test.py
+++ b/tests/devices/ed/message_ed_test.py
@@ -191,6 +191,58 @@ class TestMessageNewSet:
         expected_body = bytearray([0x15, 0x01, 0x01, 0x01, 0x02, 0x01, 0x00, 0x00])
         assert new_set.body == expected_body
 
+    def test_message_newset_tea_bar_start_to_target(self) -> None:
+        """Encode the official Lua target-temperature and heat-start packs."""
+        new_set = MessageNewSet(protocol_version=ProtocolVersion.V1)
+        new_set.target_temperature = 80
+        new_set.heating = True
+
+        assert new_set.body == bytearray(
+            [
+                0x15,
+                0x01,
+                0x02,
+                0x01,
+                0x04,
+                0x50,
+                0x0A,
+                0x00,
+                0x05,
+                0x04,
+                0x01,
+                0x00,
+                0x00,
+            ],
+        )
+
+    def test_message_newset_tea_bar_stop(self) -> None:
+        """Encode the official Lua heat-start off pack."""
+        new_set = MessageNewSet(protocol_version=ProtocolVersion.V1)
+        new_set.heating = False
+
+        assert new_set.body == bytearray(
+            [0x15, 0x01, 0x01, 0x05, 0x04, 0x00, 0x00, 0x00],
+        )
+
+    @pytest.mark.parametrize(
+        ("enabled", "duration", "raw_enabled"),
+        [(True, 6, 0x01), (False, 24, 0x00)],
+    )
+    def test_message_newset_tea_bar_keep_warm(
+        self,
+        enabled: bool,
+        duration: int,
+        raw_enabled: int,
+    ) -> None:
+        """Encode the official Lua keep-warm command and duration."""
+        new_set = MessageNewSet(protocol_version=ProtocolVersion.V1)
+        new_set.keep_warm = enabled
+        new_set.keep_warm_time = duration
+
+        assert new_set.body == bytearray(
+            [0x15, 0x01, 0x01, 0x08, 0x04, raw_enabled, duration, 0x00],
+        )
+
     def test_message_newset_soften(self) -> None:
         """Test MessageNewSet with soften (soft water machine)."""
         new_set = MessageNewSet(protocol_version=ProtocolVersion.V1)
@@ -429,6 +481,200 @@ class TestEDMessageBody06:
         assert hasattr(message, "child_lock")
         assert not message.child_lock
 
+    @pytest.mark.parametrize(
+        ("body_hex", "current_temperature", "heating", "dispensing"),
+        [
+            (
+                "0601002064645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000000000100",
+                32,
+                False,
+                False,
+            ),
+            (
+                "0601002064645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000001000500",
+                32,
+                True,
+                False,
+            ),
+            (
+                "0601002164645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000000000100",
+                33,
+                False,
+                False,
+            ),
+            (
+                "0601002264645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000000000100",
+                34,
+                False,
+                False,
+            ),
+            (
+                "0601002664645a000000000000000000000000000000000000960a0000000000000000001c00000000000000000000000000000100",
+                38,
+                False,
+                False,
+            ),
+            (
+                "0601002664645a000000000000000000000000000000000000960a0000000000000000001e00000000000000000000000000005100",
+                38,
+                False,
+                True,
+            ),
+            (
+                "0601001c64645a000000000000000000000000000000000000970a0000000000000000000e00000000000000000000000000000100",
+                28,
+                False,
+                False,
+            ),
+            (
+                "0601006464645a000000000000000000000000000000000000970a0000000000000000000e00000000000000000000000000000100",
+                100,
+                False,
+                False,
+            ),
+        ],
+    )
+    def test_tea_bar_status_reports(
+        self,
+        body_hex: str,
+        current_temperature: int,
+        heating: bool,
+        dispensing: bool,
+    ) -> None:
+        """Parse subtype 395 status from captured reports."""
+        message = EDMessageBody06(bytearray.fromhex(body_hex), subtype=395)
+        assert message.current_temperature == current_temperature
+        assert message.target_temperature is None
+        assert message.heating is heating
+        assert message.dispensing is dispensing
+        assert message.sleep is False
+        assert message.screen_display is True
+        assert message.cooling is False
+        assert message.lack_water is False
+        assert message.standby is False
+        assert message.fault_code == 0
+        assert message.fault is False
+
+    @pytest.mark.parametrize(
+        (
+            "body_hex",
+            "current_temperature",
+            "target_temperature",
+            "heating",
+            "dispensing",
+        ),
+        [
+            (
+                "0601004164645a000000460000000000000000000000000000970a0000000000000000002000000000000000000000000000005100",
+                65,
+                70,
+                False,
+                True,
+            ),
+            (
+                "0601001e64645a000000460000000000000000000000000000980a0000000000000000000c00000000000000000000000001000500",
+                30,
+                70,
+                True,
+                False,
+            ),
+            (
+                "0601004564645a000000460000000000000000000000000000980a0000000000000000000c00000000000000000000000000000100",
+                69,
+                70,
+                False,
+                False,
+            ),
+            (
+                "0601003f64645a0000004b0000000000000000000000000000980a0000000000000000000c00000000000000000000000001000500",
+                63,
+                75,
+                True,
+                False,
+            ),
+            (
+                "0601004b64645a0000004b0000000000000000000000000000980a0000000000000000000c00000000000000000000000000000100",
+                75,
+                75,
+                False,
+                False,
+            ),
+        ],
+    )
+    def test_tea_bar_voice_target_temperature_reports(
+        self,
+        body_hex: str,
+        current_temperature: int,
+        target_temperature: int,
+        heating: bool,
+        dispensing: bool,
+    ) -> None:
+        """Parse native targets throughout captured official voice flows."""
+        message = EDMessageBody06(bytearray.fromhex(body_hex), subtype=395)
+        assert message.current_temperature == current_temperature
+        assert message.target_temperature == target_temperature
+        assert message.heating is heating
+        assert message.dispensing is dispensing
+
+    def test_tea_bar_fields_are_not_parsed_for_other_subtypes(self) -> None:
+        """Do not apply subtype 395 offsets to other ED appliances."""
+        body = bytearray.fromhex(
+            "0601002064645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000001000500",
+        )
+        message = EDMessageBody06(body, subtype=394)
+        assert not hasattr(message, "current_temperature")
+        assert not hasattr(message, "target_temperature")
+        assert not hasattr(message, "heating")
+        assert not hasattr(message, "dispensing")
+        assert not hasattr(message, "keep_warm")
+        assert not hasattr(message, "keep_warm_time")
+        assert not hasattr(message, "keep_warm_remaining")
+        assert not hasattr(message, "sleep")
+        assert not hasattr(message, "screen_display")
+        assert not hasattr(message, "cooling")
+        assert not hasattr(message, "lack_water")
+        assert not hasattr(message, "standby")
+        assert not hasattr(message, "hot_water_dispensing")
+        assert not hasattr(message, "fault_code")
+        assert not hasattr(message, "fault")
+
+    def test_tea_bar_keep_warm_status_uses_official_body06_layout(self) -> None:
+        """Parse official keep-warm flag and half-hour duration encoding."""
+        body = bytearray.fromhex(
+            "0601002064645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000000000100",
+        )
+        body[33] = 6
+        body[34] = 0x4D
+        body[35] = 0x0E
+        body[48] = 0x01
+
+        message = EDMessageBody06(body, subtype=395)
+
+        assert message.keep_warm is True
+        assert message.keep_warm_time == 3
+        assert message.keep_warm_remaining == 3661
+
+    def test_tea_bar_extended_status_uses_official_body06_layout(self) -> None:
+        """Parse screen, cooling, water, standby, and fault status fields."""
+        body = bytearray.fromhex(
+            "0601002064645a000000000000000000000000000000000000950a0000000000000000005600000000000000000000000000000100",
+        )
+        body[48] = 0x80
+        body[50] = 0x01
+        body[51] = 0xC3
+        body[52] = 22
+
+        message = EDMessageBody06(body, subtype=395)
+
+        assert message.sleep is True
+        assert message.screen_display is False
+        assert message.cooling is True
+        assert message.lack_water is True
+        assert message.standby is True
+        assert message.hot_water_dispensing is True
+        assert message.fault_code == 22
+        assert message.fault is True
+
 
 class TestEDMessageBody07:
     """Test EDMessageBody07."""
@@ -663,6 +909,7 @@ class TestEDMessageBodyFF:
         assert message.out_tds == 258
         assert hasattr(message, "child_lock")
         assert message.child_lock
+
         assert hasattr(message, "life1")
         assert message.life1 == 1
         assert hasattr(message, "life2")
@@ -673,6 +920,25 @@ class TestEDMessageBodyFF:
 
 class TestMessageEDResponse:
     """Test Message ED Response."""
+
+    def test_tea_bar_new_set_status_acknowledgement(self) -> None:
+        """Parse the real subtype-395 X15 acknowledgement after stopping heat."""
+        raw = bytes.fromhex(
+            "aa3fed000000000000021501004a64645a00000050000000000000000000000000"
+            "0000980a0000000000000000005e00000000000000000000000000000100ff",
+        )
+
+        message = MessageEDResponse(raw, subtype=395)
+
+        assert message.body_type == ListTypes.X15
+        assert hasattr(message, "current_temperature")
+        assert hasattr(message, "target_temperature")
+        assert hasattr(message, "heating")
+        assert hasattr(message, "dispensing")
+        assert message.current_temperature == 74
+        assert message.target_temperature == 80
+        assert message.heating is False
+        assert message.dispensing is False
 
     def test_ed_general_response(self) -> None:
         """Test general response."""

--- a/tests/devices/ed/tea_bar_review_regression_test.py
+++ b/tests/devices/ed/tea_bar_review_regression_test.py
@@ -9,6 +9,8 @@ from midealocal.devices.ed import DeviceAttributes, MideaEDDevice
 from midealocal.devices.ed.message import MessageEDResponse
 from midealocal.message import ListTypes
 
+TEST_AUTH_VALUE = "AA"
+
 
 @pytest.mark.parametrize("reported_keep_warm_time", [None, 12.0])
 def test_tea_bar_keep_warm_uses_device_default_duration(
@@ -20,7 +22,7 @@ def test_tea_bar_keep_warm_uses_device_default_duration(
         device_id=2,
         ip_address="192.0.2.1",
         port=6444,
-        token="AA",
+        token=TEST_AUTH_VALUE,
         key="BB",
         device_protocol=ProtocolVersion.V3,
         model="63000622",

--- a/tests/devices/ed/tea_bar_review_regression_test.py
+++ b/tests/devices/ed/tea_bar_review_regression_test.py
@@ -1,0 +1,67 @@
+"""Regression tests for subtype-395 review findings."""
+
+from unittest.mock import patch
+
+import pytest
+
+from midealocal.const import ProtocolVersion
+from midealocal.devices.ed import DeviceAttributes, MideaEDDevice
+from midealocal.devices.ed.message import MessageEDResponse
+from midealocal.message import ListTypes
+
+
+@pytest.mark.parametrize("reported_keep_warm_time", [None, 12.0])
+def test_tea_bar_keep_warm_uses_device_default_duration(
+    reported_keep_warm_time: float | None,
+) -> None:
+    """Do not send an explicit duration for the appliance's 12-hour default."""
+    tea_bar = MideaEDDevice(
+        name="Tea Bar",
+        device_id=2,
+        ip_address="192.0.2.1",
+        port=6444,
+        token="AA",
+        key="BB",
+        device_protocol=ProtocolVersion.V3,
+        model="63000622",
+        subtype=395,
+        customize="",
+    )
+    tea_bar._attributes[DeviceAttributes.keep_warm_time] = reported_keep_warm_time
+
+    with patch.object(tea_bar, "build_send") as mock_build_send:
+        tea_bar.set_attribute(DeviceAttributes.keep_warm, True)
+
+    message = mock_build_send.call_args.args[0]
+    assert message.body == bytearray(
+        [0x15, 0x01, 0x01, 0x08, 0x04, 0x01, 0x00, 0x00],
+    )
+
+
+@pytest.mark.parametrize("body_size", [3, 8])
+def test_tea_bar_short_x15_acknowledgement_is_not_status_parsed(
+    body_size: int,
+) -> None:
+    """Keep short subtype-395 X15 acknowledgements without body-06 parsing."""
+    header = bytearray(
+        [
+            0xAA,
+            0x00,
+            0xED,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x02,
+        ],
+    )
+    body = bytearray(body_size)
+    body[0] = ListTypes.X15
+
+    message = MessageEDResponse(bytes(header + body + bytearray([0x00])), subtype=395)
+
+    assert message.body_type == ListTypes.X15
+    assert not hasattr(message, "current_temperature")
+    assert not hasattr(message, "fault_code")


### PR DESCRIPTION
## Summary

Add local protocol support for the Midea 0xED tea bar appliance with subtype 395. Control commands are additionally restricted to model `63000622`, so existing 0xED water purifiers and softeners keep their current behavior.

- Parse captured body-06 reports for current/target temperature, heating, dispensing, keep-warm state/time/remaining time, cooling, screen state, lack-water, standby, hot-water dispensing, and fault status.
- Add the model's official local set tags for boil target/start, keep warm/time, child lock, cooling, and screen sleep.
- Expose normalized derived state such as `boiling` and `screen_display` while retaining the protocol-level sleep value.
- Reject unsafe cooling shutdown while the appliance reports dispensing.
- Add captured-report parsing tests, command serialization tests, range validation, model/subtype isolation tests, and device state tests.

## Protocol evidence and safety

The offsets and set tags come from the official Lua protocol downloaded for model `63000622`, then were checked against real body-06 status reports and a physical appliance. No control packet was guessed. The implementation does not apply these controls to other ED models.

Related integration issue: wuwentao/midea_ac_lan#668

## Validation

- `uv run python -m pytest ./tests/` — 1518 passed.
- `uv run prek run --all-files` — all hooks passed, including ruff, formatting, mypy, pylint, codespell, and private-key detection.
- Physical validation with Home Assistant Core 2026.8.1: normal fill-and-boil, target-temperature boil, stop, live temperature/heating state, keep warm, child lock, cooling, and screen display all worked; restart persistence passed and another existing Midea device remained available.
- Privacy scan found no account, device ID, serial number, MAC, IP address, token, or key in the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tea-bar appliances, including temperature control, boiling, cooling, keep-warm, child lock, sleep, and display settings.
  * Added real-time status details such as current and target temperature, heating, dispensing, water level, faults, and remaining keep-warm time.
* **Bug Fixes**
  * Added safeguards for invalid temperatures, keep-warm durations, unsafe cooling shutdowns, and other device-specific constraints.
* **Tests**
  * Expanded coverage for tea-bar commands, status reporting, acknowledgements, and unsupported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->