### PR TITLE
fix(b0): ignore 31 body on subtype zero devices

### DIFF
--- a/midealocal/devices/b0/__init__.py
+++ b/midealocal/devices/b0/__init__.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Unpack
 
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs
+from midealocal.message import ListTypes
 
 from .message import (
     MessageB0Response,
@@ -190,6 +191,13 @@ class MideaB0Device(MideaDevice):
         """B0 Midea device process message."""
         message = MessageB0Response(bytearray(msg))
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
+        # B0Message31Body's byte layout is specific to model 0TG025JG,
+        # subtype 2. On subtype 0 devices this response still arrives, but
+        # decoding it with the wrong layout produces garbage that
+        # immediately overwrites the good data just received via the X01
+        # response a moment earlier. Ignore X31 entirely for subtype 0.
+        if self._subtype == 0 and message.body_type == ListTypes.X31:
+            return {}
         new_status = {}
         for attr in self._attributes:
             if hasattr(message, str(attr)):

--- a/tests/devices/b0/device_b0_test.py
+++ b/tests/devices/b0/device_b0_test.py
@@ -157,6 +157,38 @@ class TestMideaB0Device:
         assert device.attributes[DeviceAttributes.mode] is None
         assert new_status[DeviceAttributes.door.value] is True
 
+    def test_process_message_31_ignored_on_subtype_zero(self) -> None:
+        """A 31 body must not overwrite good data on a subtype zero device.
+
+        The 31 body layout is specific to model 0TG025JG (subtype 2). On
+        subtype zero devices it still arrives in response to Query31, but
+        decoding it with that layout produces meaningless values that would
+        otherwise clobber the good data just received via a 01 body.
+        """
+        device = _build_device(0)
+        body_01 = bytearray(34)
+        body_01[0] = 0x01
+        body_01[31] = 0x02  # status "Working"
+        body_01[32] = 0x00  # door closed, no tank/water flags
+        device.process_message(_build_message(MessageType.query, body_01))
+        assert device.attributes[DeviceAttributes.door] is False
+        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.tank_ejected] is False
+        assert device.attributes[DeviceAttributes.water_shortage] is False
+
+        body_31 = bytearray(18)
+        body_31[0] = 0x31
+        body_31[1] = 0x00  # status code not present in the subtype-zero map
+        body_31[16] = 0x4B  # child lock, door, water shortage, preheat end
+        new_status = device.process_message(
+            _build_message(MessageType.query, body_31),
+        )
+        assert new_status == {}
+        assert device.attributes[DeviceAttributes.door] is False
+        assert device.attributes[DeviceAttributes.status] == "Working"
+        assert device.attributes[DeviceAttributes.tank_ejected] is False
+        assert device.attributes[DeviceAttributes.water_shortage] is False
+
     def test_process_message_default_body_subtype_zero(self) -> None:
         """Test process message with the default body on subtype zero."""
         device = _build_device(0)


### PR DESCRIPTION
## What
  
  On subtype-zero B0 devices, the 31-body response (`B0Message31Body`) was being
  decoded and applied on top of whatever was just received from the 01-body
  response, even though its byte layout is specific to model 0TG025JG,
  subtype 2 (see the existing comments in `process_message`). On a subtype-zero
  device this produces meaningless values for `door`, `status`, 
  `tank_ejected`, `water_shortage`, `water_change_reminder` and
  `time_remaining` that immediately overwrite the good data the 01-body
  response provided a moment earlier - on every single polling cycle.
  
  ## Why
  
  Confirmed against a real subtype-zero microwave (`model 70000209`) via debug
  logs: every ~10s poll sends both `MessageQuery01` and `MessageQuery31`, and
  the 31-body response - decoded with the wrong (subtype-2) layout - clobbers
  the correct 01-body data essentially all the time. In practice this made
  `door`/`status`/etc. show stale/wrong values almost continuously, with only
  a ~100ms window of correct data right after the 01 response before the 31
  response overwrote it.
  
  ## Fix
  
  Skip processing the 31 body entirely when `subtype == 0`, since the 01 body
  already reliably provides everything this device class reports. `mode`/
  `fire_power`/`child_lock` (only ever present in the 31 body) simply stay
  unset on subtype-zero devices, same as before this change on any occasion
  the 31 body wasn't already corrupting other fields.
  
  ## Testing
  
  - Added `test_process_message_31_ignored_on_subtype_zero`, reproducing the
    scenario: a valid 01-body update followed by a 31-body response that would
    previously have overwritten it.
  - Full suite passes (`pytest ./tests/`).
  - `ruff check`, `ruff format --check`, `mypy`, `pylint` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status handling for subtype-zero devices by ignoring unsupported responses.
  * Preserved valid device attributes received from supported responses.
  * Added regression coverage to ensure device status remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->