### PR TITLE
refactor(ac)!: rename T1/T2/T3 group 1 temperature attributes

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -113,9 +113,9 @@ class DeviceAttributes(StrEnum):
     target_compressor_frequency = "target_compressor_frequency"
     compressor_current = "compressor_current"
     compressor_voltage = "compressor_voltage"
-    indoor_coil_temperature = "indoor_coil_temperature"  # T1
-    evaporator_temperature = "evaporator_temperature"  # T2
-    condenser_temperature = "condenser_temperature"  # T3
+    indoor_ambient_temperature = "indoor_ambient_temperature"  # T1
+    indoor_coil_temperature = "indoor_coil_temperature"  # T2
+    outdoor_coil_temperature = "outdoor_coil_temperature"  # T3
     outdoor_ambient_temperature = "outdoor_ambient_temperature"  # T4
     discharge_pipe_temperature = "discharge_pipe_temperature"  # TP
     # group 2: indoor fan and condensate pump
@@ -291,9 +291,9 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.target_compressor_frequency: None,
                 DeviceAttributes.compressor_current: None,
                 DeviceAttributes.compressor_voltage: None,
+                DeviceAttributes.indoor_ambient_temperature: None,
                 DeviceAttributes.indoor_coil_temperature: None,
-                DeviceAttributes.evaporator_temperature: None,
-                DeviceAttributes.condenser_temperature: None,
+                DeviceAttributes.outdoor_coil_temperature: None,
                 DeviceAttributes.outdoor_ambient_temperature: None,
                 DeviceAttributes.discharge_pipe_temperature: None,
                 DeviceAttributes.indoor_fan_speed: None,
@@ -784,9 +784,9 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.target_compressor_frequency,
             DeviceAttributes.compressor_current,
             DeviceAttributes.compressor_voltage,
+            DeviceAttributes.indoor_ambient_temperature,
             DeviceAttributes.indoor_coil_temperature,
-            DeviceAttributes.evaporator_temperature,
-            DeviceAttributes.condenser_temperature,
+            DeviceAttributes.outdoor_coil_temperature,
             DeviceAttributes.outdoor_ambient_temperature,
             DeviceAttributes.discharge_pipe_temperature,
             DeviceAttributes.indoor_fan_speed,

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -68,7 +68,7 @@ XC1_GROUP_ONE_MIN_LENGTH = 15
 XC1_GROUP_TWO_MIN_LENGTH = 9
 XC1_GROUP_SEVEN_MIN_LENGTH = 12
 # Refrigerant circuit temperatures are reported as half degrees with an offset:
-# T1/T2 (indoor coil / evaporator) use 30, T3/T4 (condenser / outdoor) use 50.
+# T1/T2 (indoor ambient / indoor coil) use 30, T3/T4 (outdoor coil / ambient) use 50.
 XC1_TEMP_INDOOR_OFFSET = 30
 XC1_TEMP_OUTDOOR_OFFSET = 50
 XC1_TEMP_DIVISOR = 2
@@ -1392,15 +1392,15 @@ class XC1MessageBody(MessageBody):
         self.target_compressor_frequency = body[5]
         self.compressor_current = body[7]
         self.compressor_voltage = body[8]
-        # T1: indoor coil, T2: evaporator outlet
-        self.indoor_coil_temperature = (
+        # T1: indoor return air, T2: indoor coil
+        self.indoor_ambient_temperature = (
             body[10] - XC1_TEMP_INDOOR_OFFSET
         ) / XC1_TEMP_DIVISOR
-        self.evaporator_temperature = (
+        self.indoor_coil_temperature = (
             body[11] - XC1_TEMP_INDOOR_OFFSET
         ) / XC1_TEMP_DIVISOR
-        # T3: condenser, T4: outdoor ambient
-        self.condenser_temperature = (
+        # T3: outdoor coil, T4: outdoor ambient
+        self.outdoor_coil_temperature = (
             body[12] - XC1_TEMP_OUTDOOR_OFFSET
         ) / XC1_TEMP_DIVISOR
         self.outdoor_ambient_temperature = (

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -606,9 +606,9 @@ class TestMideaACDevice:
             mock_message.target_compressor_frequency = 25
             mock_message.compressor_current = 1
             mock_message.compressor_voltage = 232
-            mock_message.indoor_coil_temperature = 20.5
-            mock_message.evaporator_temperature = 4.0
-            mock_message.condenser_temperature = 26.0
+            mock_message.indoor_ambient_temperature = 20.5
+            mock_message.indoor_coil_temperature = 4.0
+            mock_message.outdoor_coil_temperature = 26.0
             mock_message.outdoor_ambient_temperature = 19.0
             mock_message.discharge_pipe_temperature = 36
             # group 2
@@ -624,9 +624,9 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.target_compressor_frequency.value] == 25
             assert result[DeviceAttributes.compressor_current.value] == 1
             assert result[DeviceAttributes.compressor_voltage.value] == 232
-            assert result[DeviceAttributes.indoor_coil_temperature.value] == 20.5
-            assert result[DeviceAttributes.evaporator_temperature.value] == 4.0
-            assert result[DeviceAttributes.condenser_temperature.value] == 26.0
+            assert result[DeviceAttributes.indoor_ambient_temperature.value] == 20.5
+            assert result[DeviceAttributes.indoor_coil_temperature.value] == 4.0
+            assert result[DeviceAttributes.outdoor_coil_temperature.value] == 26.0
             assert result[DeviceAttributes.outdoor_ambient_temperature.value] == 19.0
             assert result[DeviceAttributes.discharge_pipe_temperature.value] == 36
             assert result[DeviceAttributes.indoor_fan_speed.value] == 424
@@ -642,9 +642,9 @@ class TestMideaACDevice:
                 DeviceAttributes.target_compressor_frequency,
                 DeviceAttributes.compressor_current,
                 DeviceAttributes.compressor_voltage,
+                DeviceAttributes.indoor_ambient_temperature,
                 DeviceAttributes.indoor_coil_temperature,
-                DeviceAttributes.evaporator_temperature,
-                DeviceAttributes.condenser_temperature,
+                DeviceAttributes.outdoor_coil_temperature,
                 DeviceAttributes.outdoor_ambient_temperature,
                 DeviceAttributes.discharge_pipe_temperature,
                 DeviceAttributes.indoor_fan_speed,

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1319,12 +1319,12 @@ class TestMessageACResponse:
         assert response.compressor_current == 1
         assert hasattr(response, "compressor_voltage")
         assert response.compressor_voltage == 232
+        assert hasattr(response, "indoor_ambient_temperature")
+        assert response.indoor_ambient_temperature == 20.5
         assert hasattr(response, "indoor_coil_temperature")
-        assert response.indoor_coil_temperature == 20.5
-        assert hasattr(response, "evaporator_temperature")
-        assert response.evaporator_temperature == 4.0
-        assert hasattr(response, "condenser_temperature")
-        assert response.condenser_temperature == 26.0
+        assert response.indoor_coil_temperature == 4.0
+        assert hasattr(response, "outdoor_coil_temperature")
+        assert response.outdoor_coil_temperature == 26.0
         assert hasattr(response, "outdoor_ambient_temperature")
         assert response.outdoor_ambient_temperature == 19.0
         assert hasattr(response, "discharge_pipe_temperature")


### PR DESCRIPTION
Follow-up to the group 1/2/7 diagnostics added in #490, from review feedback by
@TurboLed on wuwentao/midea_ac_lan#887.

The three refrigerant-circuit temperatures were named after their role in cooling
mode, which is wrong half the time:

| | before | after | why |
| --- | --- | --- | --- |
| T1 | `indoor_coil_temperature` | `indoor_ambient_temperature` | T1 is the return-air thermistor - the air around the indoor unit, not the coil |
| T2 | `evaporator_temperature` | `indoor_coil_temperature` | the indoor coil is the evaporator only while cooling; in heat mode it condenses |
| T3 | `condenser_temperature` | `outdoor_coil_temperature` | same, inverted - the outdoor coil is the condenser only while cooling |

Naming by location is mode-independent and matches the service-manual convention
(see [SG-RG10-01](https://cematraining.com/wp-content/uploads/2022/03/SG-RG10-01.pdf)).
T4 `outdoor_ambient_temperature` and TP `discharge_pipe_temperature` were already
location-named and are untouched. The CD (heat-pump water heater) attribute
`condenser_temperature` is a different device and is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed air-conditioner temperature readings for clearer sensor identification.
  * Indoor readings are now reported as ambient and coil temperatures.
  * Outdoor readings are now reported as outdoor coil temperature.
  * Updated device controls and read-only sensor handling to use the revised names.
* **Bug Fixes**
  * Improved consistency between reported temperature data and device sensor labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->