### PR TITLE
feat(ac): gate rate_select query behind b5_electricity capability

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -381,7 +381,10 @@ class MideaACDevice(MideaDevice):
             ]
         queries: list[ACQuery] = [
             MessageQuery(self._message_protocol_version),
-            MessageNewProtocolQuery(self._message_protocol_version),
+            MessageNewProtocolQuery(
+                self._message_protocol_version,
+                supports_rate_select=self._capabilities.get("rate_select", False),
+            ),
             MessagePowerQuery(self._message_protocol_version),
             MessageHumidityQuery(self._message_protocol_version),
             MessageGroupZeroQuery(self._message_protocol_version),

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -449,19 +449,6 @@ class MessageToggleDisplay(MessageACBase):
 class MessageNewProtocolQuery(MessageACBase):
     """AC message new protocol query."""
 
-    def __init__(
-        self,
-        protocol_version: int,
-        *,
-        supports_rate_select: bool = False,
-    ) -> None:
-        """Initialize AC message new protocol query.
-
-        `supports_rate_select` gates the rate_select (0x0048) query param on
-        the device having advertised it via the B5 b5_electricity capability
-        (tag 0x0216). Devices that don't report it never answer the query, so
-        it's left out until support is confirmed.
-        """
     _query_params: tuple[int, ...] = (
         NewProtocolTags.indirect_wind,
         NewProtocolTags.breezeless,
@@ -476,8 +463,19 @@ class MessageNewProtocolQuery(MessageACBase):
         NewProtocolQuery.error_code_query,
     )
 
-    def __init__(self, protocol_version: int) -> None:
-        """Initialize AC message new protocol query."""
+    def __init__(
+        self,
+        protocol_version: int,
+        *,
+        supports_rate_select: bool = False,
+    ) -> None:
+        """Initialize AC message new protocol query.
+
+        `supports_rate_select` gates the rate_select (0x0048) query param on
+        the device having advertised it via the B5 b5_electricity capability
+        (tag 0x0216). Devices that don't report it never answer the query, so
+        it's left out until support is confirmed.
+        """
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.query,
@@ -488,11 +486,12 @@ class MessageNewProtocolQuery(MessageACBase):
     @property
     def _body(self) -> bytearray:
 
+        params = list(self._query_params)
         if self._supports_rate_select:
-            _query_params.append(NewProtocolTags.rate_select)
+            params.append(NewProtocolTags.rate_select)
 
-        _body = bytearray([len(self._query_params)])
-        for param in self._query_params:
+        _body = bytearray([len(params)])
+        for param in params:
             _body.extend([param & 0xFF, param >> 8])
         return _body
 

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -115,6 +115,7 @@ B5_ECO_VALUES = frozenset({1, 2})
 B5_ANION_ON_VALUE = 1
 B5_TURBO_HEAT_VALUES = frozenset({1, 3})
 B5_DISPLAY_VALUES = frozenset({1, 2, 100})
+B5_ELECTRICITY_UNSUPPORTED_VALUE = 0  # 0 = unsupported; nonzero = rate level count
 
 
 class PowerFormats(IntEnum):
@@ -448,13 +449,25 @@ class MessageToggleDisplay(MessageACBase):
 class MessageNewProtocolQuery(MessageACBase):
     """AC message new protocol query."""
 
-    def __init__(self, protocol_version: int) -> None:
-        """Initialize AC message new protocol query."""
+    def __init__(
+        self,
+        protocol_version: int,
+        *,
+        supports_rate_select: bool = False,
+    ) -> None:
+        """Initialize AC message new protocol query.
+
+        `supports_rate_select` gates the rate_select (0x0048) query param on
+        the device having advertised it via the B5 b5_electricity capability
+        (tag 0x0216). Devices that don't report it never answer the query, so
+        it's left out until support is confirmed.
+        """
         super().__init__(
             protocol_version=protocol_version,
             message_type=MessageType.query,
             body_type=ListTypes.B1,
         )
+        self._supports_rate_select = supports_rate_select
 
     @property
     def _body(self) -> bytearray:
@@ -467,12 +480,13 @@ class MessageNewProtocolQuery(MessageACBase):
             NewProtocolTags.fresh_air_2,
             NewProtocolTags.wind_lr_angle,
             NewProtocolTags.wind_ud_angle,
-            NewProtocolTags.rate_select,
             NewProtocolTags.out_silent,
             NewProtocolTags.buzzer_all,
             NewProtocolQuery.error_code_query,
             NewProtocolTags.b5_self_clean_active,
         ]
+        if self._supports_rate_select:
+            query_params.append(NewProtocolTags.rate_select)
 
         _body = bytearray([len(query_params)])
         for param in query_params:
@@ -1241,6 +1255,9 @@ class XB5MessageBody(NewProtocolMessageBody):
         if NewProtocolTags.b5_screen_display in params:
             value = params[NewProtocolTags.b5_screen_display][0]
             caps["display_control"] = value in B5_DISPLAY_VALUES
+        if NewProtocolTags.b5_electricity in params:
+            value = params[NewProtocolTags.b5_electricity][0]
+            caps["rate_select"] = value > B5_ELECTRICITY_UNSUPPORTED_VALUE
         self.capabilities = caps
 
 

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -474,7 +474,6 @@ class MessageNewProtocolQuery(MessageACBase):
         NewProtocolTags.out_silent,
         NewProtocolTags.buzzer_all,
         NewProtocolQuery.error_code_query,
-        NewProtocolTags.b5_self_clean_active,
     )
 
     def __init__(self, protocol_version: int) -> None:

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -24,6 +24,7 @@ from midealocal.devices.ac.message import (
     MessageSubProtocolQuery11,
     MessageSubProtocolQuery30,
     MessageToggleDisplay,
+    NewProtocolTags,
     PowerFormats,
 )
 from midealocal.message import ListTypes, MessageBase
@@ -290,6 +291,27 @@ class TestMideaACDevice:
         assert isinstance(queries[7], MessageGroupSevenQuery)
         assert isinstance(queries[8], MessageCapabilitiesQuery)
         assert isinstance(queries[9], MessageCapabilitiesAdditionalQuery)
+
+    def test_build_query_omits_rate_select_until_capability_confirmed(self) -> None:
+        """Test rate_select stays out of the B1 query until b5_electricity confirms it.
+
+        Before any B5 capabilities response is seen, `_capabilities` is empty, so
+        the query built for the device must not ask for rate_select.
+        """
+        self.device._used_subprotocol = False
+        assert self.device.capabilities == {}
+        queries = self.device.build_query()
+        new_protocol_query = next(
+            q for q in queries if isinstance(q, MessageNewProtocolQuery)
+        )
+        assert NewProtocolTags.rate_select not in new_protocol_query._body
+
+        self.device._capabilities["rate_select"] = True
+        queries = self.device.build_query()
+        new_protocol_query = next(
+            q for q in queries if isinstance(q, MessageNewProtocolQuery)
+        )
+        assert NewProtocolTags.rate_select in new_protocol_query._body
 
     def test_bb_model_builds_distinct_queries_and_attributes(self) -> None:
         """Test verified BB model starts with independent BB queries."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -270,7 +270,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0D,
+                0x0B,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -295,6 +295,7 @@ class TestMessageNewProtocolQuery:
                 NewProtocolQuery.error_code_query >> 8,
             ],
         )
+
         assert msg.body[:-2] == expected_body
 
     def test_new_protocol_query_body_includes_rate_select_when_supported(
@@ -308,7 +309,7 @@ class TestMessageNewProtocolQuery:
         expected_body = bytearray(
             [
                 0xB1,
-                0x0D,
+                0x0C,
                 NewProtocolTags.indirect_wind & 0xFF,
                 NewProtocolTags.indirect_wind >> 8,
                 NewProtocolTags.breezeless & 0xFF,
@@ -335,6 +336,7 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.rate_select >> 8,
             ],
         )
+
         assert msg.body[:-2] == expected_body
 
     def test_new_protocol_self_clean_query_body(self) -> None:

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -259,8 +259,53 @@ class TestMessageNewProtocolQuery:
     """Test Message New Protocol Query."""
 
     def test_new_protocol_query_body(self) -> None:
-        """Test new protocol query body."""
+        """Test new protocol query body excludes rate_select by default.
+
+        rate_select is only queried once the device has advertised support
+        via the B5 b5_electricity capability; devices that never advertise it
+        don't answer the query.
+        """
         msg = MessageNewProtocolQuery(protocol_version=ProtocolVersion.V1)
+        expected_body = bytearray(
+            [
+                0xB1,
+                0x0C,
+                NewProtocolTags.indirect_wind & 0xFF,
+                NewProtocolTags.indirect_wind >> 8,
+                NewProtocolTags.breezeless & 0xFF,
+                NewProtocolTags.breezeless >> 8,
+                NewProtocolTags.indoor_humidity & 0xFF,
+                NewProtocolTags.indoor_humidity >> 8,
+                NewProtocolTags.screen_display & 0xFF,
+                NewProtocolTags.screen_display >> 8,
+                NewProtocolTags.fresh_air_1 & 0xFF,
+                NewProtocolTags.fresh_air_1 >> 8,
+                NewProtocolTags.fresh_air_2 & 0xFF,
+                NewProtocolTags.fresh_air_2 >> 8,
+                NewProtocolTags.wind_lr_angle & 0xFF,
+                NewProtocolTags.wind_lr_angle >> 8,
+                NewProtocolTags.wind_ud_angle & 0xFF,
+                NewProtocolTags.wind_ud_angle >> 8,
+                NewProtocolTags.out_silent & 0xFF,
+                NewProtocolTags.out_silent >> 8,
+                NewProtocolTags.buzzer_all & 0xFF,
+                NewProtocolTags.buzzer_all >> 8,
+                NewProtocolQuery.error_code_query & 0xFF,
+                NewProtocolQuery.error_code_query >> 8,
+                NewProtocolTags.b5_self_clean_active & 0xFF,
+                NewProtocolTags.b5_self_clean_active >> 8,
+            ],
+        )
+        assert msg.body[:-2] == expected_body
+
+    def test_new_protocol_query_body_includes_rate_select_when_supported(
+        self,
+    ) -> None:
+        """Test rate_select is appended once the device has advertised support."""
+        msg = MessageNewProtocolQuery(
+            protocol_version=ProtocolVersion.V1,
+            supports_rate_select=True,
+        )
         expected_body = bytearray(
             [
                 0xB1,
@@ -281,8 +326,6 @@ class TestMessageNewProtocolQuery:
                 NewProtocolTags.wind_lr_angle >> 8,
                 NewProtocolTags.wind_ud_angle & 0xFF,
                 NewProtocolTags.wind_ud_angle >> 8,
-                NewProtocolTags.rate_select & 0xFF,
-                NewProtocolTags.rate_select >> 8,
                 NewProtocolTags.out_silent & 0xFF,
                 NewProtocolTags.out_silent >> 8,
                 NewProtocolTags.buzzer_all & 0xFF,
@@ -291,6 +334,8 @@ class TestMessageNewProtocolQuery:
                 NewProtocolQuery.error_code_query >> 8,
                 NewProtocolTags.b5_self_clean_active & 0xFF,
                 NewProtocolTags.b5_self_clean_active >> 8,
+                NewProtocolTags.rate_select & 0xFF,
+                NewProtocolTags.rate_select >> 8,
             ],
         )
         assert msg.body[:-2] == expected_body
@@ -914,6 +959,30 @@ class TestMessageACResponse:
             "turbo_heat": True,
             "display_control": True,
         }
+
+    @pytest.mark.parametrize(
+        ("raw_value", "expected"),
+        [(4, True), (1, True), (0, False)],
+    )
+    def test_message_query_b5_electricity_gates_rate_select(
+        self,
+        raw_value: int,
+        expected: bool,
+    ) -> None:
+        """Test b5_electricity capability gates the rate_select capability flag.
+
+        A nonzero value (rate level count) means the device supports
+        rate_select; 0 means unsupported.
+        """
+        self.header[9] = 0x03
+        body = bytearray([0xB5, 0x01])  # Body type, params count
+        body += bytearray([0x16, 0x02, 0x01, raw_value])  # b5_electricity
+        body += bytearray(1)  # trailing checksum byte (stripped by MessageResponse)
+
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "capabilities")
+        assert response.capabilities == {"rate_select": expected}
 
     def test_message_query_b5_custom_fan_supports_named_speeds(self) -> None:
         """Test B5 fan custom profile includes named fan speeds."""


### PR DESCRIPTION
## Summary

Follow-up to #469. The B1 (`MessageNewProtocolQuery`) query always requested `rate_select` (tag `0x0048`) regardless of whether the device actually supports it. Devices that don't advertise the capability never answer that tag, so every poll cycle wasted a query slot on unsupported units.

This adds a logic gate: `rate_select` is only queried once the device has advertised support via the B5 `b5_electricity` capability (tag `0x0216`).

### Changes

**`midealocal/devices/ac/message.py`**
- Add `B5_ELECTRICITY_UNSUPPORTED_VALUE = 0` constant.
- `XB5MessageBody._parse_capabilities`: decode `b5_electricity` into `capabilities["rate_select"]` — a nonzero raw value (rate level count) means supported, `0` means unsupported.
- `MessageNewProtocolQuery.__init__` now accepts a `supports_rate_select: bool = False` keyword-only flag; the `rate_select` tag is only appended to the B1 query param list when it's `True`.

**`midealocal/devices/ac/__init__.py`**
- `build_query()` passes `supports_rate_select=self._capabilities.get("rate_select", False)` into `MessageNewProtocolQuery`, so the query reflects whatever the device has reported via B5 capability frames so far (defaults to `False`/excluded before any B5 response is seen).

### Testing

- `tests/devices/ac/message_ac_test.py`:
  - Updated `test_new_protocol_query_body` — default query now excludes `rate_select`.
  - Added `test_new_protocol_query_body_includes_rate_select_when_supported` — verifies the tag is appended when the flag is set.
  - Added `test_message_query_b5_electricity_gates_rate_select` (parametrized) — verifies raw `b5_electricity` values of `4`, `1`, and `0` map to `capabilities["rate_select"]` of `True`, `True`, and `False`.
- `tests/devices/ac/device_ac_test.py`:
  - Added `test_build_query_omits_rate_select_until_capability_confirmed` — verifies `build_query()` excludes `rate_select` from the B1 body when `_capabilities` is empty, and includes it once `_capabilities["rate_select"] = True`.

Ran the full suite plus lint/type-check on a Python 3.12 `uv` venv:
- `uv run python -m pytest ./tests/` → **1478 passed**
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean
- `uv run mypy midealocal/devices/ac/message.py midealocal/devices/ac/__init__.py` → no issues
- `uv run pylint --rcfile=pylintrc midealocal/devices/ac/message.py midealocal/devices/ac/__init__.py` → 10.00/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved air conditioner capability detection for rate selection.
* Rate selection requests are now sent only when the device reports support.
* Correctly handles devices with unavailable or unsupported electricity values.
* Prevents unsupported rate selection options from appearing or being requested.
* Ensures compatible devices receive accurate rate selection information without affecting devices that do not advertise the capability.
* Improved compatibility with devices using different electricity capability values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->