### PR TITLE
feat(b1): decode X01 fallback query responses

### DIFF
--- a/midealocal/devices/b1/__init__.py
+++ b/midealocal/devices/b1/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Unpack
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
-from .message import MessageB1Response, MessageQuery
+from .message import MessageB1Response, MessageQuery, MessageQueryX01
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,9 +57,18 @@ class MideaB1Device(MideaDevice):
             },
         )
 
-    def build_query(self) -> list[MessageQuery]:
-        """Midea B1 device build query."""
-        return [MessageQuery(self._message_protocol_version)]
+    def build_query(self) -> list[MessageQuery | MessageQueryX01]:
+        """Midea B1 device build query.
+
+        Some B1 devices report the X00 ``MessageQuery`` as an unsupported
+        protocol and never respond to it, leaving the device with no
+        working query at all. X01 is included as a fallback - see
+        ``MessageQueryX01``/``B1Message01Body``.
+        """
+        return [
+            MessageQuery(self._message_protocol_version),
+            MessageQueryX01(self._message_protocol_version),
+        ]
 
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Midea B1 device process message."""

--- a/midealocal/devices/b1/message.py
+++ b/midealocal/devices/b1/message.py
@@ -9,7 +9,9 @@ from midealocal.message import (
     MessageType,
 )
 
-MIN_MSG_BODY = 15
+X01_STATUS_OFFSET = 31
+X01_FLAGS_OFFSET = 32
+X01_MIN_BODY_LENGTH = X01_FLAGS_OFFSET + 1
 
 
 class MessageB1Base(MessageRequest):
@@ -99,19 +101,19 @@ class B1Message01Body(MessageBody):
 
     Layout confirmed against a real subtype-zero electric oven (model
     711001CJ): identical byte offsets to B0's ``B0Message01Body``, which
-    makes sense given the shared appliance-family protocol. Only the
-    door bit has not yet been confirmed against an actual door-open
-    sample - everything else (status, time_remaining, temperature,
-    tank/water flags) produced sane values matching the device's known
-    idle state.
+    makes sense given the shared appliance-family protocol. The door bit
+    is confirmed correct: a physical test that opened the oven door for
+    real showed ``door=True`` (open) with no inversion needed - everything
+    else (status, time_remaining, temperature, tank/water flags) produced
+    sane values matching the device's known idle state.
     """
 
     def __init__(self, body: bytearray) -> None:
         """Initialize B1 message 01 body."""
         super().__init__(body)
-        if len(body) > MIN_MSG_BODY:
-            self.door = (body[32] & 0x02) > 0
-            self.status = body[31]
+        if len(body) >= X01_MIN_BODY_LENGTH:
+            self.door = (body[X01_FLAGS_OFFSET] & 0x02) > 0
+            self.status = body[X01_STATUS_OFFSET]
             self.time_remaining = (
                 (0 if body[22] == MAX_BYTE_VALUE else body[22]) * 3600
                 + (0 if body[23] == MAX_BYTE_VALUE else body[23]) * 60
@@ -120,9 +122,9 @@ class B1Message01Body(MessageBody):
             self.current_temperature = (body[25] << 8) + body[26]
             if self.current_temperature == 0:
                 self.current_temperature = (body[27] << 8) + body[28]
-            self.tank_ejected = (body[32] & 0x04) > 0
-            self.water_shortage = (body[32] & 0x08) > 0
-            self.water_change_reminder = (body[32] & 0x10) > 0
+            self.tank_ejected = (body[X01_FLAGS_OFFSET] & 0x04) > 0
+            self.water_shortage = (body[X01_FLAGS_OFFSET] & 0x08) > 0
+            self.water_change_reminder = (body[X01_FLAGS_OFFSET] & 0x10) > 0
 
 
 class MessageB1Response(MessageResponse):

--- a/midealocal/devices/b1/message.py
+++ b/midealocal/devices/b1/message.py
@@ -9,6 +9,8 @@ from midealocal.message import (
     MessageType,
 )
 
+MIN_MSG_BODY = 15
+
 
 class MessageB1Base(MessageRequest):
     """B1 message base."""
@@ -48,6 +50,31 @@ class MessageQuery(MessageB1Base):
         return bytearray([])
 
 
+class MessageQueryX01(MessageB1Base):
+    """B1 message query, X01 body variant.
+
+    Some B1 devices report ``MessageQuery`` (the X00 body) as an
+    unsupported protocol and never respond to it at all, leaving the
+    device with no working query (the B0 device has this same X00-query
+    problem on some models, with X01/X31 fallbacks that work instead).
+    This is the equivalent X01 fallback for B1, confirmed against a real
+    subtype-zero electric oven to return a response decodable with the
+    same byte layout as B0's X01 body (see ``B1Message01Body``).
+    """
+
+    def __init__(self, protocol_version: int) -> None:
+        """Initialize B1 message query X01."""
+        super().__init__(
+            protocol_version=protocol_version,
+            message_type=MessageType.query,
+            body_type=ListTypes.X01,
+        )
+
+    @property
+    def _body(self) -> bytearray:
+        return bytearray([])
+
+
 class B1MessageBody(MessageBody):
     """B1 message body."""
 
@@ -67,6 +94,37 @@ class B1MessageBody(MessageBody):
         self.water_change_reminder = (body[16] & 0x10) > 0
 
 
+class B1Message01Body(MessageBody):
+    """B1 message 01 body.
+
+    Layout confirmed against a real subtype-zero electric oven (model
+    711001CJ): identical byte offsets to B0's ``B0Message01Body``, which
+    makes sense given the shared appliance-family protocol. Only the
+    door bit has not yet been confirmed against an actual door-open
+    sample - everything else (status, time_remaining, temperature,
+    tank/water flags) produced sane values matching the device's known
+    idle state.
+    """
+
+    def __init__(self, body: bytearray) -> None:
+        """Initialize B1 message 01 body."""
+        super().__init__(body)
+        if len(body) > MIN_MSG_BODY:
+            self.door = (body[32] & 0x02) > 0
+            self.status = body[31]
+            self.time_remaining = (
+                (0 if body[22] == MAX_BYTE_VALUE else body[22]) * 3600
+                + (0 if body[23] == MAX_BYTE_VALUE else body[23]) * 60
+                + (0 if body[24] == MAX_BYTE_VALUE else body[24])
+            )
+            self.current_temperature = (body[25] << 8) + body[26]
+            if self.current_temperature == 0:
+                self.current_temperature = (body[27] << 8) + body[28]
+            self.tank_ejected = (body[32] & 0x04) > 0
+            self.water_shortage = (body[32] & 0x08) > 0
+            self.water_change_reminder = (body[32] & 0x10) > 0
+
+
 class MessageB1Response(MessageResponse):
     """B1 message response."""
 
@@ -74,5 +132,8 @@ class MessageB1Response(MessageResponse):
         """Initialize B1 message response."""
         super().__init__(bytearray(message))
         if self.message_type in [MessageType.notify1, MessageType.query]:
-            self.set_body(B1MessageBody(super().body))
+            if self.body_type == ListTypes.X01:
+                self.set_body(B1Message01Body(super().body))
+            else:
+                self.set_body(B1MessageBody(super().body))
         self.set_attr()

--- a/midealocal/devices/b1/message.py
+++ b/midealocal/devices/b1/message.py
@@ -12,6 +12,13 @@ from midealocal.message import (
 X01_STATUS_OFFSET = 31
 X01_FLAGS_OFFSET = 32
 X01_MIN_BODY_LENGTH = X01_FLAGS_OFFSET + 1
+X01_TIME_REMAINING_HOURS_OFFSET = 22
+X01_TIME_REMAINING_MINUTES_OFFSET = 23
+X01_TIME_REMAINING_SECONDS_OFFSET = 24
+X01_TEMPERATURE_HIGH_OFFSET = 25
+X01_TEMPERATURE_LOW_OFFSET = 26
+X01_TEMPERATURE_FALLBACK_HIGH_OFFSET = 27
+X01_TEMPERATURE_FALLBACK_LOW_OFFSET = 28
 
 
 class MessageB1Base(MessageRequest):
@@ -115,13 +122,31 @@ class B1Message01Body(MessageBody):
             self.door = (body[X01_FLAGS_OFFSET] & 0x02) > 0
             self.status = body[X01_STATUS_OFFSET]
             self.time_remaining = (
-                (0 if body[22] == MAX_BYTE_VALUE else body[22]) * 3600
-                + (0 if body[23] == MAX_BYTE_VALUE else body[23]) * 60
-                + (0 if body[24] == MAX_BYTE_VALUE else body[24])
+                (
+                    0
+                    if body[X01_TIME_REMAINING_HOURS_OFFSET] == MAX_BYTE_VALUE
+                    else body[X01_TIME_REMAINING_HOURS_OFFSET]
+                )
+                * 3600
+                + (
+                    0
+                    if body[X01_TIME_REMAINING_MINUTES_OFFSET] == MAX_BYTE_VALUE
+                    else body[X01_TIME_REMAINING_MINUTES_OFFSET]
+                )
+                * 60
+                + (
+                    0
+                    if body[X01_TIME_REMAINING_SECONDS_OFFSET] == MAX_BYTE_VALUE
+                    else body[X01_TIME_REMAINING_SECONDS_OFFSET]
+                )
             )
-            self.current_temperature = (body[25] << 8) + body[26]
+            self.current_temperature = (body[X01_TEMPERATURE_HIGH_OFFSET] << 8) + body[
+                X01_TEMPERATURE_LOW_OFFSET
+            ]
             if self.current_temperature == 0:
-                self.current_temperature = (body[27] << 8) + body[28]
+                self.current_temperature = (
+                    body[X01_TEMPERATURE_FALLBACK_HIGH_OFFSET] << 8
+                ) + body[X01_TEMPERATURE_FALLBACK_LOW_OFFSET]
             self.tank_ejected = (body[X01_FLAGS_OFFSET] & 0x04) > 0
             self.water_shortage = (body[X01_FLAGS_OFFSET] & 0x08) > 0
             self.water_change_reminder = (body[X01_FLAGS_OFFSET] & 0x10) > 0

--- a/tests/devices/b1/device_b1_test.py
+++ b/tests/devices/b1/device_b1_test.py
@@ -4,7 +4,11 @@ import pytest
 
 from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.devices.b1 import DeviceAttributes, MideaB1Device
-from midealocal.devices.b1.message import MessageB1Base, MessageQuery
+from midealocal.devices.b1.message import (
+    MessageB1Base,
+    MessageQuery,
+    MessageQueryX01,
+)
 from midealocal.message import ListTypes, MessageType
 
 
@@ -42,8 +46,9 @@ class TestMideaB1Device:
     def test_build_query(self) -> None:
         """Test build query."""
         queries = self.device.build_query()
-        assert len(queries) == 1
+        assert len(queries) == 2
         assert isinstance(queries[0], MessageQuery)
+        assert isinstance(queries[1], MessageQueryX01)
 
     def test_set_attribute(self) -> None:
         """Test set attribute is a no-op."""
@@ -99,6 +104,35 @@ class TestMideaB1Device:
         body = bytearray(20)
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert result == {}
+
+    def test_x01_response_real_device_sample(self) -> None:
+        """Test X01 response decoding against a real subtype-zero oven capture.
+
+        Captured via debug logs from a real electric oven (model 711001CJ,
+        subtype 0) answering ``MessageQueryX01`` while idle with the door
+        closed. Confirms the X01 body layout matches B0's ``B0Message01Body``
+        offsets (see ``B1Message01Body``) and produces sane values: door
+        closed, no tank/water flags, idle status, no time remaining, and a
+        plausible ~32C cavity temperature (rather than B0's known-broken
+        sentinel value on devices without a temperature sensor).
+        """
+        header = bytearray(
+            [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
+        ) + bytearray([MessageType.query])
+        body = bytearray.fromhex(
+            "010000000011000000000000000000ffff00000000000000000020ffff"
+            "0000020000000000000000000000000001910300010000000000008000"
+            "0021",
+        )
+        result = self.device.process_message(bytes(header + body + bytearray(1)))
+        assert self.device.attributes[DeviceAttributes.door] is False
+        assert self.device.attributes[DeviceAttributes.status] == "Idle"
+        assert self.device.attributes[DeviceAttributes.time_remaining] == 0
+        assert self.device.attributes[DeviceAttributes.current_temperature] == 32
+        assert self.device.attributes[DeviceAttributes.tank_ejected] is False
+        assert self.device.attributes[DeviceAttributes.water_shortage] is False
+        assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
+        assert result[DeviceAttributes.status.value] == "Idle"
 
 
 class TestMessageB1Base:

--- a/tests/devices/b1/device_b1_test.py
+++ b/tests/devices/b1/device_b1_test.py
@@ -114,6 +114,58 @@ class TestMideaB1Device:
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert result == {}
 
+    def test_x01_response_short_body_guard(self) -> None:
+        """Test X01 response shorter than X01_MIN_BODY_LENGTH is ignored safely.
+
+        Truncates the real captured X01 payload to 32 bytes (one short of
+        the 33-byte minimum enforced by ``B1Message01Body``) to exercise
+        the length guard's false branch: it must not raise ``IndexError``
+        and must leave door/status/time_remaining/etc. unset, so no
+        attributes change from their initial values.
+        """
+        header = bytearray(
+            [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
+        ) + bytearray([MessageType.query])
+        body = bytearray.fromhex(self.X01_RESPONSE_711001CJ_HEX)[:32]
+        result = self.device.process_message(bytes(header + body + bytearray(1)))
+        assert self.device.attributes[DeviceAttributes.door] is False
+        assert self.device.attributes[DeviceAttributes.status] is None
+        assert self.device.attributes[DeviceAttributes.time_remaining] is None
+        assert self.device.attributes[DeviceAttributes.current_temperature] is None
+        assert self.device.attributes[DeviceAttributes.tank_ejected] is False
+        assert self.device.attributes[DeviceAttributes.water_shortage] is False
+        assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
+        assert result == {}
+
+    def test_x01_response_temperature_fallback(self) -> None:
+        """Test X01 response falls back to the secondary temperature bytes.
+
+        When the primary temperature reading (``body[25:27]``) is zero,
+        ``B1Message01Body`` falls back to the secondary bytes
+        (``body[27:29]``) instead. Builds a synthetic minimal-length X01
+        body (the 33-byte guard minimum) with a zero primary reading and a
+        non-zero secondary reading to exercise that fallback branch.
+        """
+        header = bytearray(
+            [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
+        ) + bytearray([MessageType.query])
+        body = bytearray(33)
+        body[0] = 0x01  # X01 body type marker
+        body[25] = 0x00  # primary temperature high byte
+        body[26] = 0x00  # primary temperature low byte -> reads as 0
+        body[27] = 0x00  # fallback temperature high byte
+        body[28] = 0x14  # fallback temperature low byte -> 20
+        body[31] = 0x02  # status -> Idle
+        result = self.device.process_message(bytes(header + body + bytearray(1)))
+        assert self.device.attributes[DeviceAttributes.door] is False
+        assert self.device.attributes[DeviceAttributes.status] == "Idle"
+        assert self.device.attributes[DeviceAttributes.time_remaining] == 0
+        assert self.device.attributes[DeviceAttributes.current_temperature] == 20
+        assert self.device.attributes[DeviceAttributes.tank_ejected] is False
+        assert self.device.attributes[DeviceAttributes.water_shortage] is False
+        assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
+        assert result[DeviceAttributes.status.value] == "Idle"
+
     def test_x01_response_real_device_sample(self) -> None:
         """Test X01 response decoding against a real subtype-zero oven capture.
 
@@ -159,3 +211,12 @@ class TestMessageQuery:
         """Test query body."""
         msg = MessageQuery(protocol_version=ProtocolVersion.V1)
         assert msg.body == bytearray([0x00])
+
+
+class TestMessageQueryX01:
+    """Test B1 Message Query X01."""
+
+    def test_query_body(self) -> None:
+        """Test query body."""
+        msg = MessageQueryX01(protocol_version=ProtocolVersion.V1)
+        assert msg.body == bytearray([0x01])

--- a/tests/devices/b1/device_b1_test.py
+++ b/tests/devices/b1/device_b1_test.py
@@ -17,6 +17,15 @@ class TestMideaB1Device:
 
     device: MideaB1Device
 
+    # Real-device X01 response captured via debug logs from a real electric
+    # oven (model 711001CJ, subtype 0) answering ``MessageQueryX01`` while
+    # idle with the door closed.
+    X01_RESPONSE_711001CJ_HEX = (
+        "010000000011000000000000000000ffff00000000000000000020ffff"
+        "0000020000000000000000000000000001910300010000000000008000"
+        "0021"
+    )
+
     @pytest.fixture(autouse=True)
     def _setup_device(self) -> None:
         """Midea B1 Device setup."""
@@ -108,9 +117,7 @@ class TestMideaB1Device:
     def test_x01_response_real_device_sample(self) -> None:
         """Test X01 response decoding against a real subtype-zero oven capture.
 
-        Captured via debug logs from a real electric oven (model 711001CJ,
-        subtype 0) answering ``MessageQueryX01`` while idle with the door
-        closed. Confirms the X01 body layout matches B0's ``B0Message01Body``
+        Confirms the X01 body layout matches B0's ``B0Message01Body``
         offsets (see ``B1Message01Body``) and produces sane values: door
         closed, no tank/water flags, idle status, no time remaining, and a
         plausible ~32C cavity temperature (rather than B0's known-broken
@@ -119,11 +126,7 @@ class TestMideaB1Device:
         header = bytearray(
             [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
         ) + bytearray([MessageType.query])
-        body = bytearray.fromhex(
-            "010000000011000000000000000000ffff00000000000000000020ffff"
-            "0000020000000000000000000000000001910300010000000000008000"
-            "0021",
-        )
+        body = bytearray.fromhex(self.X01_RESPONSE_711001CJ_HEX)
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is False
         assert self.device.attributes[DeviceAttributes.status] == "Idle"


### PR DESCRIPTION
## Problem

B1 devices (Midea electric ovens, e.g. model 711001CJ) only query via `MessageQuery` (`X00` body
type). On our unit this response comes back as an unsupported/unparsed protocol type, so `door`,
`status`, `time_remaining`, `current_temperature`, etc. never get exposed at all — the entity data
stays permanently unknown.

## Root cause

The library has no `X01`-body query/parser for B1, even though the same device type's `X01`
byte layout already exists for B0 (`B0Message01Body`) — same manufacturer, same generation of
protocol, compatible offsets.

## Fix

- Add `MessageQueryX01` and `B1Message01Body` to `midealocal/devices/b1/message.py`, reusing the
  same byte offsets as `B0Message01Body`.
- `build_query()` now sends both `MessageQuery` and `MessageQueryX01`, so devices that don't
  support the base `X00` query still get valid state via the `X01` fallback.

## Testing

- Added `test_x01_response_real_device_sample` (`tests/devices/b1/device_b1_test.py`), replaying
  a real captured packet from a physical device.
- Verified against the live device (model 711001CJ) after deploying: `status`, `time_remaining`,
  `current_temperature` all report correctly and match the physical oven's real-time state.
- `door` polarity confirmed against a second physical test with the door held open:
  `door=True` when open, no inversion needed.
- Full test suite, ruff, mypy, pylint all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for devices that reject standard queries by using an X01 fallback query.
  * Added decoding for X01 responses, including temperature, operating status, door state, remaining time, and water-related indicators.

* **Bug Fixes**
  * Improved compatibility with devices using the alternate X01 response format.

* **Tests**
  * Added coverage for X01 query generation and real-device response decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->