### PR TITLE
chore: tweak x40 preset_modes

### DIFF
--- a/midealocal/devices/x40/__init__.py
+++ b/midealocal/devices/x40/__init__.py
@@ -69,10 +69,10 @@ class MideaX40Device(MideaDevice):
         return 2
 
     @property
-    def preset_modes(self) -> list[str] | None:
+    def preset_modes(self) -> list[str]:
         """Midea x40 device preset modes."""
         # X40 has no "mode" attribute, so it has no named presets.
-        return None
+        return []
 
     @property
     def directions(self) -> list[str]:

--- a/tests/devices/x40/device_x40_test.py
+++ b/tests/devices/x40/device_x40_test.py
@@ -59,6 +59,14 @@ class TestMideaX40Device:
         """Test the available directions."""
         assert self.device.directions == ["60", "70", "80", "90", "100", "Oscillate"]
 
+    def test_speed_count(self) -> None:
+        """Test the speed count."""
+        assert self.device.speed_count == 2
+
+    def test_preset_modes(self) -> None:
+        """Test the available preset modes."""
+        assert self.device.preset_modes == []
+
     @pytest.mark.parametrize(
         ("direction", "expected"),
         [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of preset modes by returning an empty list when no modes are available.
  * Ensured preset mode results are consistently provided in a list format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->