### PR TITLE
fix(ac)!: standard snake_case for wind_angles

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -205,18 +205,18 @@ class MideaACDevice(MideaDevice):
     _wind_lr_angles: ClassVar[dict[int, str]] = {
         0: "off",
         1: "left",
-        25: "left-mid",
+        25: "left_mid",
         50: "middle",
-        75: "right-mid",
+        75: "right_mid",
         100: "right",
     }
 
     _wind_ud_angles: ClassVar[dict[int, str]] = {
         0: "off",
         1: "up",
-        25: "up-mid",
+        25: "up_mid",
         50: "middle",
-        75: "down-mid",
+        75: "down_mid",
         100: "down",
     }
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -492,17 +492,17 @@ class TestMideaACDevice:
         assert self.device.wind_lr_angles == [
             "off",
             "left",
-            "left-mid",
+            "left_mid",
             "middle",
-            "right-mid",
+            "right_mid",
             "right",
         ]
         assert self.device.wind_ud_angles == [
             "off",
             "up",
-            "up-mid",
+            "up_mid",
             "middle",
-            "down-mid",
+            "down_mid",
             "down",
         ]
         assert self.device.rate_selects == ["1", "20", "40", "60", "80", "100"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated intermediate wind-direction labels to use consistent underscore formatting.
  * Aligned wind-angle options for left, right, up, and down intermediate positions with the updated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->