### PR TITLE
fix(b1)!: snake_case status

### DIFF
--- a/midealocal/devices/b1/__init__.py
+++ b/midealocal/devices/b1/__init__.py
@@ -28,12 +28,12 @@ class MideaB1Device(MideaDevice):
     """Midea B1 device."""
 
     _status: ClassVar[dict[int, str]] = {
-        0x01: "Standby",
-        0x02: "Idle",
-        0x03: "Working",
-        0x04: "Finished",
-        0x05: "Delay",
-        0x06: "Paused",
+        0x01: "standby",
+        0x02: "idle",
+        0x03: "working",
+        0x04: "finished",
+        0x05: "delay",
+        0x06: "paused",
     }
 
     def __init__(

--- a/tests/devices/b1/device_b1_test.py
+++ b/tests/devices/b1/device_b1_test.py
@@ -70,7 +70,7 @@ class TestMideaB1Device:
             [0xAA, 0x00, DeviceType.B1] + [0x00] * 5 + [ProtocolVersion.V1],
         ) + bytearray([MessageType.query])
         body = bytearray(20)
-        body[1] = 0x03  # status -> Working
+        body[1] = 0x03  # status -> working
         body[6] = 0x01  # hours
         body[7] = 0x02  # minutes
         body[8] = 0x03  # seconds
@@ -78,13 +78,13 @@ class TestMideaB1Device:
         body[19] = 0x32  # current_temperature
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is True
-        assert self.device.attributes[DeviceAttributes.status] == "Working"
+        assert self.device.attributes[DeviceAttributes.status] == "working"
         assert self.device.attributes[DeviceAttributes.time_remaining] == 3723
         assert self.device.attributes[DeviceAttributes.current_temperature] == 50
         assert self.device.attributes[DeviceAttributes.tank_ejected] is True
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is True
         assert self.device.attributes[DeviceAttributes.water_shortage] is True
-        assert result[DeviceAttributes.status.value] == "Working"
+        assert result[DeviceAttributes.status.value] == "working"
 
     def test_notify_response_invalid_status(self) -> None:
         """Test notify1 response with unknown status and invalid times."""
@@ -155,16 +155,16 @@ class TestMideaB1Device:
         body[26] = 0x00  # primary temperature low byte -> reads as 0
         body[27] = 0x00  # fallback temperature high byte
         body[28] = 0x14  # fallback temperature low byte -> 20
-        body[31] = 0x02  # status -> Idle
+        body[31] = 0x02  # status -> idle
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is False
-        assert self.device.attributes[DeviceAttributes.status] == "Idle"
+        assert self.device.attributes[DeviceAttributes.status] == "idle"
         assert self.device.attributes[DeviceAttributes.time_remaining] == 0
         assert self.device.attributes[DeviceAttributes.current_temperature] == 20
         assert self.device.attributes[DeviceAttributes.tank_ejected] is False
         assert self.device.attributes[DeviceAttributes.water_shortage] is False
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
-        assert result[DeviceAttributes.status.value] == "Idle"
+        assert result[DeviceAttributes.status.value] == "idle"
 
     def test_x01_response_real_device_sample(self) -> None:
         """Test X01 response decoding against a real subtype-zero oven capture.
@@ -181,13 +181,13 @@ class TestMideaB1Device:
         body = bytearray.fromhex(self.X01_RESPONSE_711001CJ_HEX)
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is False
-        assert self.device.attributes[DeviceAttributes.status] == "Idle"
+        assert self.device.attributes[DeviceAttributes.status] == "idle"
         assert self.device.attributes[DeviceAttributes.time_remaining] == 0
         assert self.device.attributes[DeviceAttributes.current_temperature] == 32
         assert self.device.attributes[DeviceAttributes.tank_ejected] is False
         assert self.device.attributes[DeviceAttributes.water_shortage] is False
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is False
-        assert result[DeviceAttributes.status.value] == "Idle"
+        assert result[DeviceAttributes.status.value] == "idle"
 
 
 class TestMessageB1Base:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized B1 device status labels to lowercase, including `working` and `idle`.
  * Ensured status values are consistent across device attributes and processed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->