### PR TITLE
fix(b6)!: snake_case speeds

### DIFF
--- a/midealocal/devices/b6/__init__.py
+++ b/midealocal/devices/b6/__init__.py
@@ -48,7 +48,7 @@ class MideaB6Device(MideaDevice):
                 DeviceAttributes.cleaning_reminder: False,
             },
         )
-        self._default_speeds = {0: "Off", 1: "Level 1", 2: "Level 2"}
+        self._default_speeds = {0: "off", 1: "low", 2: "high"}
         self._default_power_speed = 2
         self._power_speed = self._default_power_speed
         self._speeds = self._default_speeds

--- a/tests/devices/b6/device_b6_test.py
+++ b/tests/devices/b6/device_b6_test.py
@@ -53,7 +53,7 @@ class TestMideaB6Device:
         assert self.device.attributes[DeviceAttributes.oilcup_full] is False
         assert self.device.attributes[DeviceAttributes.cleaning_reminder] is False
         assert self.device.speed_count == 2
-        assert self.device.preset_modes == ["Off", "Level 1", "Level 2"]
+        assert self.device.preset_modes == ["off", "low", "high"]
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -69,12 +69,12 @@ class TestMideaB6Device:
         )
         assert self.device.attributes[DeviceAttributes.power] is True
         assert self.device.attributes[DeviceAttributes.light] is True
-        assert self.device.attributes[DeviceAttributes.mode] == "Level 2"
+        assert self.device.attributes[DeviceAttributes.mode] == "high"
         assert self.device.attributes[DeviceAttributes.fan_level] == 2
         assert self.device.attributes[DeviceAttributes.fan_speed] == 2
         assert self.device.attributes[DeviceAttributes.oilcup_full] is True
         assert self.device.attributes[DeviceAttributes.cleaning_reminder] is True
-        assert new_status[DeviceAttributes.mode.value] == "Level 2"
+        assert new_status[DeviceAttributes.mode.value] == "high"
         assert new_status[DeviceAttributes.fan_speed.value] == 2
 
     def test_process_message_unknown_fan_level(self) -> None:
@@ -101,7 +101,7 @@ class TestMideaB6Device:
         assert self.device._message_protocol_version == 0x02
         assert self.device.attributes[DeviceAttributes.power] is True
         assert self.device.attributes[DeviceAttributes.light] is True
-        assert self.device.attributes[DeviceAttributes.mode] == "Level 1"
+        assert self.device.attributes[DeviceAttributes.mode] == "low"
         assert self.device.attributes[DeviceAttributes.fan_speed] == 1
         assert self.device.attributes[DeviceAttributes.oilcup_full] is True
         assert self.device.attributes[DeviceAttributes.cleaning_reminder] is False
@@ -124,7 +124,7 @@ class TestMideaB6Device:
             self.device.set_attribute(DeviceAttributes.fan_speed.value, 5)
             mock_build_send.assert_not_called()
 
-            self.device.set_attribute(DeviceAttributes.mode.value, "Level 1")
+            self.device.set_attribute(DeviceAttributes.mode.value, "low")
             mock_build_send.assert_called_once()
             mock_build_send.reset_mock()
 
@@ -163,7 +163,7 @@ class TestMideaB6Device:
     def test_turn_on_with_mode(self) -> None:
         """Test turn on with a mode name applies the matching fan level."""
         with patch.object(self.device, "build_send") as mock_build_send:
-            self.device.turn_on(mode="Level 1")
+            self.device.turn_on(mode="low")
             mock_build_send.assert_called_once()
             assert mock_build_send.call_args[0][0].fan_level == 1
             mock_build_send.reset_mock()
@@ -176,20 +176,20 @@ class TestMideaB6Device:
         """Test set customize."""
         self.device.set_customize(
             '{"default_speed": 1,'
-            ' "speeds": {"1": "Low", "0": "Off", "2": "Mid", "3": "High"}}',
+            ' "speeds": {"1": "low", "0": "off", "2": "mid", "3": "high"}}',
         )
         assert self.device.speed_count == 3
-        assert self.device.preset_modes == ["Off", "Low", "Mid", "High"]
+        assert self.device.preset_modes == ["off", "low", "mid", "high"]
         assert self.device._power_speed == 1
 
     def test_set_customize_empty_params(self) -> None:
         """Test set customize with an empty JSON object."""
         self.device.set_customize("{}")
-        assert self.device.preset_modes == ["Off", "Level 1", "Level 2"]
+        assert self.device.preset_modes == ["off", "low", "high"]
         assert self.device._power_speed == 2
 
     def test_set_customize_invalid(self) -> None:
         """Test set customize with invalid JSON keeps defaults."""
         self.device.set_customize("{")
-        assert self.device.preset_modes == ["Off", "Level 1", "Level 2"]
+        assert self.device.preset_modes == ["off", "low", "high"]
         assert self.device._power_speed == 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated B6 device speed labels to use consistent lowercase names: `off`, `low`, and `high`.
  * Updated B6 preset modes to include the standardized `off`, `low`, `mid`, and `high` names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->