### PR TITLE
fix(bf)!: status snake_case

### DIFF
--- a/midealocal/devices/bf/__init__.py
+++ b/midealocal/devices/bf/__init__.py
@@ -28,12 +28,12 @@ class MideaBFDevice(MideaDevice):
     """Midea BF device."""
 
     _status: ClassVar[dict[int, str]] = {
-        0x01: "PowerSave",
-        0x02: "Standby",
-        0x03: "Working",
-        0x04: "Finished",
-        0x05: "Delay",
-        0x06: "Paused",
+        0x01: "power_save",
+        0x02: "standby",
+        0x03: "working",
+        0x04: "finished",
+        0x05: "delay",
+        0x06: "paused",
     }
 
     def __init__(
@@ -75,7 +75,7 @@ class MideaBFDevice(MideaDevice):
                             MideaBFDevice._status.get(value)
                         )
                     else:
-                        self._attributes[DeviceAttributes.status] = "Unknown"
+                        self._attributes[DeviceAttributes.status] = "unknown"
                 else:
                     self._attributes[status] = value
                 new_status[str(status)] = self._attributes[status]

--- a/tests/devices/bf/device_bf_test.py
+++ b/tests/devices/bf/device_bf_test.py
@@ -65,13 +65,13 @@ class TestMideaBFDevice:
         body[32] = 0x16  # door + tank_ejected + change_reminder
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is True
-        assert self.device.attributes[DeviceAttributes.status] == "Working"
+        assert self.device.attributes[DeviceAttributes.status] == "working"
         assert self.device.attributes[DeviceAttributes.time_remaining] == 3661
         assert self.device.attributes[DeviceAttributes.current_temperature] == 300
         assert self.device.attributes[DeviceAttributes.tank_ejected] is True
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is True
         assert self.device.attributes[DeviceAttributes.water_shortage] is None
-        assert result[DeviceAttributes.status.value] == "Working"
+        assert result[DeviceAttributes.status.value] == "working"
 
     def test_notify_response_fallback_temperature(self) -> None:
         """Test notify1 response with fallback temperature and unknown status."""
@@ -88,7 +88,7 @@ class TestMideaBFDevice:
         body[31] = 0x07  # unknown status
         self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is False
-        assert self.device.attributes[DeviceAttributes.status] == "Unknown"
+        assert self.device.attributes[DeviceAttributes.status] == "unknown"
         assert self.device.attributes[DeviceAttributes.time_remaining] == 0
         assert self.device.attributes[DeviceAttributes.current_temperature] == 100
         assert self.device.attributes[DeviceAttributes.tank_ejected] is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized BF device status labels to lowercase.
  * Unrecognized statuses are now consistently shown as “unknown.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->