### PR TITLE
fix(dc)!: snakecase progress

### DIFF
--- a/midealocal/devices/dc/__init__.py
+++ b/midealocal/devices/dc/__init__.py
@@ -141,14 +141,14 @@ class MideaDCDevice(MideaDevice):
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = {}
         progress = [
-            "Prog0",
-            "Prog1",
-            "Prog2",
-            "Prog3",
-            "Prog4",
-            "Prog5",
-            "Prog6",
-            "Prog7",
+            "prog0",
+            "prog1",
+            "prog2",
+            "prog3",
+            "prog4",
+            "prog5",
+            "prog6",
+            "prog7",
         ]
         for status in self._attributes:
             if hasattr(message, str(status)):

--- a/tests/devices/dc/device_dc_test.py
+++ b/tests/devices/dc/device_dc_test.py
@@ -108,7 +108,7 @@ class TestMideaDCDevice:
         body[16] = 0x02  # progress bit 1
         crc = bytearray([0x00])
         self.device.process_message(bytes(header + body + crc))
-        assert self.device.attributes[DeviceAttributes.progress] == "Prog1"
+        assert self.device.attributes[DeviceAttributes.progress] == "prog1"
 
     def test_notify1_response_unmapped_values(self) -> None:
         """Test notify1 response with unmapped status and program values."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized device progress labels to lowercase (`prog0`–`prog7`) for consistent status reporting.
  - Updated progress mapping expectations to reflect the corrected labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->