### PR TITLE
fix(c3): eco message index out of bounds

### DIFF
--- a/midealocal/devices/c3/message.py
+++ b/midealocal/devices/c3/message.py
@@ -385,8 +385,10 @@ class C3ECOBody(MessageBody):
     def __init__(self, body: bytearray, data_offset: int = 0) -> None:
         """Initialize C3 ECO message body."""
         super().__init__(body)
-        self.eco_function_state = body[data_offset] & 0x01 > 0
-        self.eco_timer_state = body[data_offset] & 0x02 > 0
+        self.eco_function_state = (
+            len(body) > data_offset and body[data_offset] & 0x01 > 0
+        )
+        self.eco_timer_state = len(body) > data_offset and body[data_offset] & 0x02 > 0
 
 
 class C3DisinfectBody(MessageBody):

--- a/midealocal/devices/c3/message.py
+++ b/midealocal/devices/c3/message.py
@@ -12,6 +12,8 @@ from midealocal.message import (
 )
 
 TEMP_NEG_VALUE = 127
+ECO_FUNCTION_STATE_MASK = 0x01
+ECO_TIMER_STATE_MASK = 0x02
 
 
 class C3SilentLevel(IntEnum):
@@ -386,9 +388,11 @@ class C3ECOBody(MessageBody):
         """Initialize C3 ECO message body."""
         super().__init__(body)
         self.eco_function_state = (
-            len(body) > data_offset and body[data_offset] & 0x01 > 0
+            len(body) > data_offset and body[data_offset] & ECO_FUNCTION_STATE_MASK > 0
         )
-        self.eco_timer_state = len(body) > data_offset and body[data_offset] & 0x02 > 0
+        self.eco_timer_state = (
+            len(body) > data_offset and body[data_offset] & ECO_TIMER_STATE_MASK > 0
+        )
 
 
 class C3DisinfectBody(MessageBody):

--- a/tests/devices/c3/message_c3_test.py
+++ b/tests/devices/c3/message_c3_test.py
@@ -368,23 +368,49 @@ class TestMessageC3Response:
         assert hasattr(response, "silent_level")
         assert response.silent_level == C3SilentLevel.SUPER_SILENT.name
 
-    def test_message_eco_response(self) -> None:
+    @pytest.mark.parametrize(
+        ("body", "eco_function_state", "eco_timer_state"),
+        [
+            pytest.param(
+                bytearray([ListTypes.X07, 0x03, 0x00]),
+                True,
+                True,
+                id="eco on, timer on",
+            ),
+            pytest.param(
+                bytearray([ListTypes.X07, 0x00, 0x00]),
+                False,
+                False,
+                id="eco off, timer off",
+            ),
+            pytest.param(
+                bytearray([ListTypes.X07, 0x01, 0x00]),
+                True,
+                False,
+                id="eco on, timer off",
+            ),
+            pytest.param(
+                bytearray([ListTypes.X07, 0x00]),
+                False,
+                False,
+                id="eco missing, timer missing",
+            ),
+        ],
+    )
+    def test_message_eco_response(
+        self,
+        body: bytearray,
+        eco_function_state: bool,
+        eco_timer_state: bool,
+    ) -> None:
         """Test message ECO response."""
         self.header[-1] = MessageType.query
-        body = bytearray([ListTypes.X07, 0x03, 0x00])
         response = MessageC3Response(bytes(self.header + body))
         assert response.body_type == ListTypes.X07
         assert hasattr(response, "eco_function_state")
-        assert response.eco_function_state is True
+        assert response.eco_function_state is eco_function_state
         assert hasattr(response, "eco_timer_state")
-        assert response.eco_timer_state is True
-
-        body[1] = 0x0
-        response = MessageC3Response(bytes(self.header + body))
-        assert hasattr(response, "eco_function_state")
-        assert response.eco_function_state is False
-        assert hasattr(response, "eco_timer_state")
-        assert response.eco_timer_state is False
+        assert response.eco_timer_state is eco_timer_state
 
     def test_message_disinfect_response(self) -> None:
         """Test message disinfect response."""


### PR DESCRIPTION
Fixes: #606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of short ECO responses to prevent errors when state information is missing.
  * ECO and timer status are now reported correctly across supported response variations.

* **Tests**
  * Expanded coverage for ECO and timer combinations, including responses with missing state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->