### PR TITLE
build: improve version tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "include-commit-authors": true,
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Before: `midea-local-v7.0.0`
After: `v9.0.0`

Both configuration values currently default to true:
- "include-v-in-tag"
- "include-component-in-tag"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tagging configuration to include version numbers in tags.
  * Simplified tag names by removing component names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->