### PR TITLE
fix(x26)!: snakecase modes and directions

### DIFF
--- a/midealocal/devices/x26/__init__.py
+++ b/midealocal/devices/x26/__init__.py
@@ -32,13 +32,13 @@ class Midea26Device(MideaDevice):
     """Midea x26 device."""
 
     _modes: ClassVar[list[str]] = [
-        "Off",
-        "Heat(high)",
-        "Heat(low)",
-        "Bath",
-        "Blow",
-        "Ventilation",
-        "Dry",
+        "off",
+        "heat_high",
+        "heat_low",
+        "bath",
+        "blow",
+        "ventilation",
+        "dry",
     ]
     _directions: ClassVar[list[str]] = [
         "60",
@@ -48,7 +48,7 @@ class Midea26Device(MideaDevice):
         "100",
         "110",
         "120",
-        "Oscillate",
+        "oscillate",
     ]
 
     def __init__(
@@ -75,7 +75,7 @@ class Midea26Device(MideaDevice):
 
     @staticmethod
     def _convert_to_midea_direction(direction: str) -> int:
-        if direction == "Oscillate":
+        if direction == "oscillate":
             result = 0xFD
         else:
             result = (

--- a/tests/devices/x26/device_x26_test.py
+++ b/tests/devices/x26/device_x26_test.py
@@ -61,13 +61,13 @@ class TestMidea26Device:
     def test_preset_modes(self) -> None:
         """Test preset modes property."""
         assert self.device.preset_modes == [
-            "Off",
-            "Heat(high)",
-            "Heat(low)",
-            "Bath",
-            "Blow",
-            "Ventilation",
-            "Dry",
+            "off",
+            "heat_high",
+            "heat_low",
+            "bath",
+            "blow",
+            "ventilation",
+            "dry",
         ]
 
     def test_directions(self) -> None:
@@ -80,13 +80,13 @@ class TestMidea26Device:
             "100",
             "110",
             "120",
-            "Oscillate",
+            "oscillate",
         ]
 
     @pytest.mark.parametrize(
         ("direction", "expected"),
         [
-            ("Oscillate", 0xFD),
+            ("oscillate", 0xFD),
             ("60", 60),
             ("90", 90),
             ("120", 120),
@@ -121,13 +121,13 @@ class TestMidea26Device:
     @pytest.mark.parametrize(
         ("values", "expected_mode", "expected_direction"),
         [
-            ({9: 1, 10: 55, 12: 90}, "Heat(high)", "90"),
-            ({9: 1, 10: 30, 12: 60}, "Heat(low)", "60"),
-            ({13: 1, 17: 0xFD}, "Bath", "Oscillate"),
-            ({26: 1, 28: 120}, "Blow", "120"),
-            ({18: 1, 20: 100}, "Ventilation", "100"),
-            ({21: 1, 25: 55}, "Dry", "Oscillate"),
-            ({}, "Off", "Oscillate"),
+            ({9: 1, 10: 55, 12: 90}, "heat_high", "90"),
+            ({9: 1, 10: 30, 12: 60}, "heat_low", "60"),
+            ({13: 1, 17: 0xFD}, "bath", "oscillate"),
+            ({26: 1, 28: 120}, "blow", "120"),
+            ({18: 1, 20: 100}, "ventilation", "100"),
+            ({21: 1, 25: 55}, "dry", "oscillate"),
+            ({}, "off", "oscillate"),
         ],
     )
     def test_process_message_modes(
@@ -196,8 +196,8 @@ class TestMidea26Device:
 
     def test_set_attribute_main_light(self) -> None:
         """Test set attribute main light resets lights and sets the value."""
-        self.device._attributes[DeviceAttributes.mode] = "Off"
-        self.device._attributes[DeviceAttributes.direction] = "Oscillate"
+        self.device._attributes[DeviceAttributes.mode] = "off"
+        self.device._attributes[DeviceAttributes.direction] = "oscillate"
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.main_light.value, True)
             mock_build_send.assert_called_once()
@@ -210,8 +210,8 @@ class TestMidea26Device:
 
     def test_set_attribute_night_light(self) -> None:
         """Test set attribute night light sends the value."""
-        self.device._attributes[DeviceAttributes.mode] = "Off"
-        self.device._attributes[DeviceAttributes.direction] = "Oscillate"
+        self.device._attributes[DeviceAttributes.mode] = "off"
+        self.device._attributes[DeviceAttributes.direction] = "oscillate"
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.night_light.value, True)
             mock_build_send.assert_called_once()
@@ -222,10 +222,10 @@ class TestMidea26Device:
 
     def test_set_attribute_mode(self) -> None:
         """Test set attribute mode converts the name to its index."""
-        self.device._attributes[DeviceAttributes.mode] = "Off"
-        self.device._attributes[DeviceAttributes.direction] = "Oscillate"
+        self.device._attributes[DeviceAttributes.mode] = "off"
+        self.device._attributes[DeviceAttributes.direction] = "oscillate"
         with patch.object(self.device, "build_send") as mock_build_send:
-            self.device.set_attribute(DeviceAttributes.mode.value, "Bath")
+            self.device.set_attribute(DeviceAttributes.mode.value, "bath")
             mock_build_send.assert_called_once()
             message = mock_build_send.call_args[0][0]
             assert isinstance(message, MessageSet)
@@ -233,8 +233,8 @@ class TestMidea26Device:
 
     def test_set_attribute_direction(self) -> None:
         """Test set attribute direction converts the name to degrees."""
-        self.device._attributes[DeviceAttributes.mode] = "Off"
-        self.device._attributes[DeviceAttributes.direction] = "Oscillate"
+        self.device._attributes[DeviceAttributes.mode] = "off"
+        self.device._attributes[DeviceAttributes.direction] = "oscillate"
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.set_attribute(DeviceAttributes.direction.value, "90")
             mock_build_send.assert_called_once()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated X26 device mode and direction labels to use consistent lowercase values.
  * Corrected recognition of the `oscillate` direction.
  * Improved consistency when parsing device messages and setting mode or direction values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->